### PR TITLE
Add node for executing Python code

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
       "quantum-circuit": "quantum/terra/quantum-circuit/quantum-circuit.js",
       "quantum-register": "quantum/terra/quantum-register/quantum-register.js",
       "classical-register": "quantum/terra/classical-register/classical-register.js",
-      "aer-simulator": "quantum/aer/aer-simulator/aer-simulator.js"
+      "aer-simulator": "quantum/aer/aer-simulator/aer-simulator.js",
+      "execute": "quantum/terra/execute/execute.js"
     }
   }
 }

--- a/quantum/python-shell.js
+++ b/quantum/python-shell.js
@@ -5,13 +5,13 @@ const pythonShell = require('python-shell').PythonShell;
 const pythonPath = path.resolve(appRoot, 'venv/bin/python');
 
 /**
- * Runs a Python script and returns collected messages
+ * Runs a Python script file.
  * @param {string}   scriptPath Directory path to the script (excludes file name)
  * @param {string}   scriptName File name of the script
  * @param {string[]} args       Arguments to pass to the script
  * @param {Function} callback   Callback function to invoke with the script results
 */
-module.exports = function(scriptPath, scriptName, args, callback) {
+module.exports.runScript = function(scriptPath, scriptName, args, callback) {
   if (!fileSystem.existsSync(pythonPath)) {
     throw new Error('cannot resolve Python virtual environment - execute the "npm run setup" command');
   }
@@ -21,5 +21,25 @@ module.exports = function(scriptPath, scriptName, args, callback) {
     scriptPath: scriptPath,
     args: args,
   };
+
   pythonShell.run(scriptName, options, callback);
+};
+
+/**
+ * Runs a string of Python code.
+ * @param {string}   code     Python code to be executed
+ * @param {string[]} args     Arguments to pass to the code
+ * @param {Function} callback Callback function to invoke with the code results
+*/
+module.exports.runString = function(code, args, callback) {
+  if (!fileSystem.existsSync(pythonPath)) {
+    throw new Error('cannot resolve Python virtual environment - execute the "npm run setup" command');
+  }
+
+  const options = {
+    pythonPath: pythonPath,
+    args: args,
+  };
+
+  pythonShell.runString(code, options, callback);
 };

--- a/quantum/terra/execute/execute.html
+++ b/quantum/terra/execute/execute.html
@@ -1,0 +1,29 @@
+<script type="text/javascript">
+  RED.nodes.registerType("execute", {
+    category: "quantum",
+    color: "#33B1FF",
+    defaults: {
+      name: { value: "" },
+    },
+    inputs: 1,
+    outputs: 1,
+    icon: "function.svg",
+    paletteLabel: "execute",
+    label: function () {
+      return this.name || "execute";
+    },
+  });
+</script>
+
+<script type="text/html" data-template-name="execute">
+  <div class="form-row">
+    <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+    <input type="text" id="node-input-name" placeholder="Name" />
+  </div>
+</script>
+
+<script type="text/html" data-help-name="execute">
+  <p>
+    Executes Qiskit code within a Python shell.
+  </p>
+</script>

--- a/quantum/terra/execute/execute.js
+++ b/quantum/terra/execute/execute.js
@@ -1,0 +1,23 @@
+module.exports = function(RED) {
+  'use strict';
+
+  const shell = require('../../python-shell');
+
+  function ExecuteNode(config) {
+    RED.nodes.createNode(this, config);
+    const node = this;
+
+    this.on('input', function(msg) {
+      shell.runString(msg.payload, null, function(err, output) {
+        if (err) {
+          node.error(err);
+        } else {
+          msg.payload = output;
+          node.send(msg);
+        }
+      });
+    });
+  }
+
+  RED.nodes.registerType('execute', ExecuteNode);
+};

--- a/quantum/terra/quantum-circuit/quantum-circuit.js
+++ b/quantum/terra/quantum-circuit/quantum-circuit.js
@@ -1,7 +1,7 @@
 module.exports = function(RED) {
   'use strict';
 
-  const runShell = require('../../python-shell');
+  const shell = require('../../python-shell');
 
   function QuantumCircuitNode(config) {
     RED.nodes.createNode(this, config);
@@ -10,7 +10,7 @@ module.exports = function(RED) {
     const node = this;
 
     this.on('input', function(msg) {
-      runShell(__dirname, 'quantum-circuit.py', [node.qubits, node.cbits], function(err, output) {
+      shell.runScript(__dirname, 'quantum-circuit.py', [node.qubits, node.cbits], function(err, output) {
         if (err) throw err;
         msg.payload = output;
         node.send(msg);


### PR DESCRIPTION
### Purpose
Added a node that accepts a string of Python code from msg.payload. If the Python code fails to execute, an error message is sent to the debug console. If the code successfully executes, the result is sent via msg.payload.

### Changes
- Added a runString function to python-shell.js for executing a string of Python code [(preview)](https://github.com/louislefevre/node-red-contrib-quantum/compare/master...louis/script-node?expand=1#diff-20d9056a5d9674723ba14a26a7e0a42239b2ae53b10e96d09adef5dcc88f1f7aR28-R45).
- Added a new 'execute' node.

### New Requirements
- Exported functions from python-shell.js must now be referred to by name, e.g.:
  ```
  const shell = require('../../python-shell');
  shell.runScript(...)
  shell.runString(...)
  ```
