### PR TITLE
Communicating the number of qubits from circuit start to output nodes

### DIFF
--- a/quantum/nodes/classical-register/classical-register.js
+++ b/quantum/nodes/classical-register/classical-register.js
@@ -49,6 +49,7 @@ module.exports = function(RED) {
 
       // Completing the 'quantumCircuit' flow context array
       let register = {
+        registerType: 'classical',
         registerName: node.name,
         registerVar: 'cr' + msg.payload.register.toString(),
       };
@@ -60,15 +61,26 @@ module.exports = function(RED) {
         let structure = flowContext.get('quantumCircuit');
 
         let count = 0;
+        let qreg = 0;
+        let creg = 0;
         structure.map((x) => {
           if (typeof(x) !== 'undefined') {
             count += 1;
+            if (x.registerType === 'quantum') qreg += 1;
+            else creg += 1;
           }
         });
 
+        // If the user specified a register structure in the 'Quantum Circuit' node that
+        // does not match the visual structure built using the register nodes, throw an error
+        if (qreg > msg.payload.structure.qreg || creg > msg.payload.structure.creg) {
+          throw new Error(
+              'Please enter the correct number of quantum & classical registers in the "Quantum Circuit" node.',
+          );
+
         // If all set & the quantum circuit has not yet been initialised by another register:
         // Initialise the quantum circuit
-        if (count == structure.length && typeof(flowContext.get('quantumCircuit')) !== undefined) {
+        } else if (count == structure.length && typeof(flowContext.get('quantumCircuit')) !== undefined) {
           // Delete the 'quantumCircuit' flow context variable, not used anymore
           flowContext.set('quantumCircuit', undefined);
 

--- a/quantum/nodes/classical-register/classical-register.js
+++ b/quantum/nodes/classical-register/classical-register.js
@@ -49,10 +49,8 @@ module.exports = function(RED) {
 
       // Completing the 'quantumCircuit' flow context array
       let register = {
-        registerType: 'classical',
         registerName: node.name,
         registerVar: 'cr' + msg.payload.register.toString(),
-        bits: node.classicalBits,
       };
       flowContext.set('quantumCircuit[' + msg.payload.register.toString() + ']', register);
 

--- a/quantum/nodes/quantum-circuit/quantum-circuit.html
+++ b/quantum/nodes/quantum-circuit/quantum-circuit.html
@@ -5,7 +5,16 @@
     defaults: {
       name: { value: "" },
       structure: { value: "", required: true },
-      cbits: { 
+      qbitsreg:{
+        value: "", 
+        required: true, 
+        validate: function (x) {
+          x = parseInt(x);
+          if (Number.isInteger(x) && x > 0){return true} 
+          else {return false}
+        }
+      },
+      cbitsreg: { 
         value: "", 
         required: true, 
         validate: function (x) {
@@ -15,13 +24,7 @@
         }
       },
       outputs: { 
-        value: "", 
-        required: true,
-        validate: function (x) {
-          x = parseInt(x);
-          if (Number.isInteger(x) && x > 0){return true} 
-          else {return false}
-        },
+        value: "",
       }
     },
     inputs: 1,
@@ -42,33 +45,39 @@
     oneditprepare: function () {
       if (document.getElementById("node-input-structure").value == "qubits") {
         $(".circuit-structure-qubits").addClass("selected");
-        $(".cbits").show();
-        document.getElementById("number-outputs").innerHTML = "Number of qubits";
+        document.getElementById("number-qbitsreg").innerHTML = "Number of qubits";
+        document.getElementById("number-cbitsreg").innerHTML = "Number of classical bits";
       } else {
         document.getElementById("node-input-structure").value = "registers";
         $(".circuit-structure-registers").addClass("selected");
-        $(".cbits").hide();
-        document.getElementById("number-outputs").innerHTML = "Number of registers";
-        document.getElementById("node-input-cbits").value = 1; // Required node property
+        document.getElementById("number-qbitsreg").innerHTML = "Number of quantum registers";
+        document.getElementById("number-cbitsreg").innerHTML = "Number of classical registers";
       }
 
       $(".circuit-structure-qubits").on("click", function () {
         $(".circuit-structure-registers").removeClass("selected");
         $(this).addClass("selected");
-        $(".cbits").show();
-        document.getElementById("number-outputs").innerHTML = "Number of qubits";
+        document.getElementById("number-qbitsreg").innerHTML = "Number of qubits";
+        document.getElementById("number-cbitsreg").innerHTML = "Number of classical bits";
         document.getElementById("node-input-structure").value = "qubits";
-        document.getElementById("node-input-cbits").value = "";
       });
 
       $(".circuit-structure-registers").on("click", function () {
         $(".circuit-structure-qubits").removeClass("selected");
         $(this).addClass("selected");
-        $(".cbits").hide();
-        document.getElementById("number-outputs").innerHTML = "Number of registers";
+        document.getElementById("number-qbitsreg").innerHTML = "Number of quantum registers";
+        document.getElementById("number-cbitsreg").innerHTML = "Number of classical registers";
         document.getElementById("node-input-structure").value = "registers";
-        document.getElementById("node-input-cbits").value = 1; // Required node property
       });
+    },
+
+    oneditsave: function () {
+      if (document.getElementById("node-input-structure").value == "qubits") {
+        this.outputs = (parseInt(document.getElementById("node-input-qbitsreg").value) || 1);
+      } else {
+        this.outputs = ((parseInt(document.getElementById("node-input-qbitsreg").value) +
+          parseInt(document.getElementById("node-input-cbitsreg").value)) || 1);
+      }
     },
   });
 </script>
@@ -87,12 +96,12 @@
     </span>
   </div>
   <div class="form-row">
-    <label for="node-input-number-registers" id="number-outputs"><i class="fa"></i> </label>
-    <input type="number" min="1" id="node-input-outputs" />
+    <label for="node-input-qbitsreg" id="number-qbitsreg"><i class="fa"></i> </label>
+    <input type="number" min="1" id="node-input-qbitsreg"/>
   </div>
-  <div class="form-row cbits">
-    <label for="node-input-number-cbits"><i class="fa"></i>Number of classical bits</label>
-    <input type="number" min="1" id="node-input-cbits" />
+  <div class="form-row">
+    <label for="node-input-cbitsreg" id="number-cbitsreg"><i class="fa"></i> </label>
+    <input type="number" min="1" id="node-input-cbitsreg"/>
   </div>
   <!-- Do not delete -->
   <div hidden>

--- a/quantum/nodes/quantum-circuit/quantum-circuit.js
+++ b/quantum/nodes/quantum-circuit/quantum-circuit.js
@@ -35,6 +35,7 @@ module.exports = function(RED) {
           output[i] = {
             topic: 'Quantum Circuit',
             payload: {
+              structure: new Array(node.outputs),
               register: i,
             },
           };
@@ -52,6 +53,10 @@ module.exports = function(RED) {
           output[i] = {
             topic: 'Quantum Circuit',
             payload: {
+              structure: {
+                qubits: node.outputs,
+                cbits: node.cbits,
+              },
               register: undefined,
               qubit: i,
             },

--- a/quantum/nodes/quantum-circuit/quantum-circuit.js
+++ b/quantum/nodes/quantum-circuit/quantum-circuit.js
@@ -10,7 +10,8 @@ module.exports = function(RED) {
     RED.nodes.createNode(this, config);
     this.name = config.name;
     this.structure = config.structure;
-    this.cbits = parseInt(config.cbits);
+    this.qbitsreg = parseInt(config.qbitsreg);
+    this.cbitsreg = parseInt(config.cbitsreg);
     this.outputs = parseInt(config.outputs);
     const flowContext = this.context().flow;
     const output = new Array(this.outputs);
@@ -35,14 +36,17 @@ module.exports = function(RED) {
           output[i] = {
             topic: 'Quantum Circuit',
             payload: {
-              structure: new Array(node.outputs),
+              structure: {
+                creg: node.cbitsreg,
+                qreg: node.qbitsreg,
+              },
               register: i,
             },
           };
         };
       } else { // If the user does not want to use registers
         // Add arguments to quantum circuit code
-        let circuitScript = util.format(snippets.QUANTUM_CIRCUIT, node.outputs + ',' + node.cbits);
+        let circuitScript = util.format(snippets.QUANTUM_CIRCUIT, node.qbitsreg + ',' + node.cbitsreg);
         await shell.execute(circuitScript, (err) => {
           if (err) node.error(err);
         });
@@ -54,8 +58,8 @@ module.exports = function(RED) {
             topic: 'Quantum Circuit',
             payload: {
               structure: {
-                qubits: node.outputs,
-                cbits: node.cbits,
+                qubits: node.qbitsreg,
+                cbits: node.cbitsreg,
               },
               register: undefined,
               qubit: i,

--- a/quantum/nodes/quantum-register/quantum-register.js
+++ b/quantum/nodes/quantum-register/quantum-register.js
@@ -87,12 +87,19 @@ module.exports = function(RED) {
         }
       }
 
+      let structure = msg.payload.structure;
+      structure[msg.payload.register] = {
+        register: 'qr' + msg.payload.register.toString(),
+        qubits: node.outputs,
+      };
+
       // Creating an array of messages to be sent
       // Each message represents a different qubit
       for (let i = 0; i < node.outputs; i++) {
         output[i] = {
           topic: 'Quantum Circuit',
           payload: {
+            structure: structure,
             register: node.name,
             registerVar: 'qr' + msg.payload.register.toString(),
             qubit: i,

--- a/quantum/nodes/quantum-register/quantum-register.js
+++ b/quantum/nodes/quantum-register/quantum-register.js
@@ -49,6 +49,7 @@ module.exports = function(RED) {
 
       // Completing the 'quantumCircuit' flow context array
       let register = {
+        registerType: 'quantum',
         registerName: node.name,
         registerVar: 'qr' + msg.payload.register.toString(),
       };
@@ -60,15 +61,26 @@ module.exports = function(RED) {
         let structure = flowContext.get('quantumCircuit');
 
         let count = 0;
+        let qreg = 0;
+        let creg = 0;
         structure.map((x) => {
           if (typeof(x) !== 'undefined') {
             count += 1;
+            if (x.registerType === 'quantum') qreg += 1;
+            else creg += 1;
           }
         });
 
+        // If the user specified a register structure in the 'Quantum Circuit' node that
+        // does not match the visual structure built using the register nodes, throw an error
+        if (qreg > msg.payload.structure.qreg || creg > msg.payload.structure.creg) {
+          throw new Error(
+              'Please enter the correct number of quantum & classical registers in the "Quantum Circuit" node.',
+          );
+
         // If all set & the quantum circuit has not yet been initialised by another register:
         // Initialise the quantum circuit
-        if (count == structure.length && typeof(flowContext.get('quantumCircuit')) !== undefined) {
+        } else if (count == structure.length && typeof(flowContext.get('quantumCircuit')) !== undefined) {
           // Delete the 'quantumCircuit' flow context variable, not used anymore
           flowContext.set('quantumCircuit', undefined);
 

--- a/quantum/nodes/quantum-register/quantum-register.js
+++ b/quantum/nodes/quantum-register/quantum-register.js
@@ -49,10 +49,8 @@ module.exports = function(RED) {
 
       // Completing the 'quantumCircuit' flow context array
       let register = {
-        registerType: 'quantum',
         registerName: node.name,
         registerVar: 'qr' + msg.payload.register.toString(),
-        bits: node.outputs,
       };
       flowContext.set('quantumCircuit[' + msg.payload.register.toString() + ']', register);
 
@@ -87,21 +85,16 @@ module.exports = function(RED) {
         }
       }
 
-      let structure = msg.payload.structure;
-      structure[msg.payload.register] = {
-        register: 'qr' + msg.payload.register.toString(),
-        qubits: node.outputs,
-      };
-
       // Creating an array of messages to be sent
       // Each message represents a different qubit
       for (let i = 0; i < node.outputs; i++) {
         output[i] = {
           topic: 'Quantum Circuit',
           payload: {
-            structure: structure,
+            structure: msg.payload.structure,
             register: node.name,
             registerVar: 'qr' + msg.payload.register.toString(),
+            totalQubits: node.outputs,
             qubit: i,
           },
         };

--- a/quantum/nodes/toffoli-gate/toffoli-gate.js
+++ b/quantum/nodes/toffoli-gate/toffoli-gate.js
@@ -1,9 +1,9 @@
-"use strict";
-const util = require("util");
-const snippets = require("../../snippets");
-const shell = require("../../python").PythonShell;
+'use strict';
+const util = require('util');
+const snippets = require('../../snippets');
+const shell = require('../../python').PythonShell;
 
-module.exports = function (RED) {
+module.exports = function(RED) {
   function ToffoliGateNode(config) {
     RED.nodes.createNode(this, config);
     this.name = config.name;
@@ -11,26 +11,26 @@ module.exports = function (RED) {
     this.targetPosition = config.targetPosition;
     const node = this;
 
-    this.on("input", async function (msg, send, done) {
+    this.on('input', async function(msg, send, done) {
       // Throw a connection error if:
       // - The user connects it to a node that is not from the quantum library.
       // - The user does not input a qubit object in the node.
       // - The user chooses to use registers but does not initiate them.
-      if (msg.topic !== "Quantum Circuit") {
+      if (msg.topic !== 'Quantum Circuit') {
         throw new Error(
-          "The Toffoli Gate must be connected to nodes from the quantum library only."
+            'The Toffoli Gate must be connected to nodes from the quantum library only.',
         );
       } else if (
-        typeof msg.payload.register === "undefined" &&
-        typeof msg.payload.qubit === "undefined"
+        typeof msg.payload.register === 'undefined' &&
+        typeof msg.payload.qubit === 'undefined'
       ) {
         throw new Error(
-          "The Toffoli Gate nodes must receive qubits objects as inputs.\n" +
-            'Please use "Quantum Circuit" & "Quantum Register" nodes to generate qubits objects.'
+            'The Toffoli Gate nodes must receive qubits objects as inputs.\n' +
+            'Please use "Quantum Circuit" & "Quantum Register" nodes to generate qubits objects.',
         );
-      } else if (typeof msg.payload.qubit === "undefined") {
+      } else if (typeof msg.payload.qubit === 'undefined') {
         throw new Error(
-          'If "Registers & Bits" was selected in the "Quantum Circuit" node, please make use of register nodes.'
+            'If "Registers & Bits" was selected in the "Quantum Circuit" node, please make use of register nodes.',
         );
       }
 
@@ -40,7 +40,7 @@ module.exports = function (RED) {
       // If all qubits have arrived, we first reorder the node.qubits array for output consistency
       if (node.qubits.length == 3) {
         node.qubits.sort(function compare(a, b) {
-          if (typeof a.payload.register !== "undefined") {
+          if (typeof a.payload.register !== 'undefined') {
             const regA = parseInt(a.payload.registerVar.slice(2));
             const regB = parseInt(b.payload.registerVar.slice(2));
             if (regA < regB) return -1;
@@ -55,17 +55,17 @@ module.exports = function (RED) {
           }
         });
 
-        //Initialise qubit variables for script.
+        // Initialise qubit variables for script.
         let control1 = node.qubits[0];
         let control2 = node.qubits[0];
         let target = node.qubits[0];
 
-        //Determine which node is the target based on position.
-        if (node.targetPosition == "Top") {
+        // Determine which node is the target based on position.
+        if (node.targetPosition == 'Top') {
           target = node.qubits[0];
           control1 = node.qubits[1];
           control2 = node.qubits[2];
-        } else if (node.targetPosition == "Middle") {
+        } else if (node.targetPosition == 'Middle') {
           target = node.qubits[1];
           control1 = node.qubits[0];
           control2 = node.qubits[2];
@@ -76,32 +76,32 @@ module.exports = function (RED) {
         }
 
         // Generate the corresponding Toffoli Gate Qiskit script
-        let toffoliCode = "";
+        let toffoliCode = '';
         node.qubits.map((msg) => {
-          //Use qubits only if there are no registers.
-          if (typeof msg.payload.register === "undefined") {
+          // Use qubits only if there are no registers.
+          if (typeof msg.payload.register === 'undefined') {
             toffoliCode = util.format(
-              snippets.TOFFOLI_GATE,
-              control1.payload.qubit.toString(),
-              control2.payload.qubit.toString(),
-              target.payload.qubit.toString()
+                snippets.TOFFOLI_GATE,
+                control1.payload.qubit.toString(),
+                control2.payload.qubit.toString(),
+                target.payload.qubit.toString(),
             );
           } else {
-            //Use registers if there are quantum registers.
+            // Use registers if there are quantum registers.
             toffoliCode = util.format(
-              snippets.TOFFOLI_GATE,
-              control1.payload.registerVar +
-                "[" +
+                snippets.TOFFOLI_GATE,
+                control1.payload.registerVar +
+                '[' +
                 control1.payload.qubit.toString() +
-                "]",
-              control2.payload.registerVar +
-                "[" +
+                ']',
+                control2.payload.registerVar +
+                '[' +
                 control2.payload.qubit.toString() +
-                "]",
-              target.payload.registerVar +
-                "[" +
+                ']',
+                target.payload.registerVar +
+                '[' +
                 target.payload.qubit.toString() +
-                "]"
+                ']',
             );
           }
         });
@@ -111,11 +111,11 @@ module.exports = function (RED) {
           if (err) node.error(err);
         });
 
-        //Sending one qubit object per node output
+        // Sending one qubit object per node output
         send(node.qubits);
       }
     });
   }
 
-  RED.nodes.registerType("toffoli-gate", ToffoliGateNode);
+  RED.nodes.registerType('toffoli-gate', ToffoliGateNode);
 };

--- a/quantum/snippets.js
+++ b/quantum/snippets.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 /*
  * Snippets must be constants, and constants must capitalised with underscores.
@@ -12,26 +12,26 @@
 
 // Probably shouldn't use wildcard import here for efficiency but whatever will
 // worry about it later.
-const IMPORTS = 
+const IMPORTS =
 `import numpy as np
  from qiskit import *`;
 
-const QUANTUM_CIRCUIT = 
+const QUANTUM_CIRCUIT =
 `qc = QuantumCircuit(%s)`;
 
-const CLASSICAL_REGISTER = 
+const CLASSICAL_REGISTER =
 `cr%s = ClassicalRegister(%s)`;
 
-const QUANTUM_REGISTER = 
+const QUANTUM_REGISTER =
 `qr%s = QuantumRegister(%s)`;
 
-const TOFFOLI_GATE = 
+const TOFFOLI_GATE =
 `qc.toffoli(%s, %s, %s)`;
 
-const CNOT_GATE = 
+const CNOT_GATE =
 `qc.cx(%s, %s)`;
 
-const BARRIER = 
+const BARRIER =
 `qc.barrier(%s)`;
 
 const HADAMARD_GATE =


### PR DESCRIPTION
### Purpose
Changed the 'Quantum Circuit' node properties when using registers. Instead of having one input "Number of registers", we now have 2 inputs "Number of Q-registers" & "Number of C-registers".

This allows passing information in `msg.payload` to the 'output' nodes about the number of qubits expected.

Error handling for when the user inputs a register structure in the 'Quantum Circuit' node that does not match the visual register structure. 