### PR TITLE
Louis/parallel-nodes-fixes

### DIFF
--- a/quantum/nodes/cnot-gate/cnot-gate.js
+++ b/quantum/nodes/cnot-gate/cnot-gate.js
@@ -12,6 +12,7 @@ module.exports = function(RED) {
     const node = this;
 
     this.on('input', async function(msg, send, done) {
+      let script = '';
       // Throw a connection error if:
       // - The user connects it to a node that is not from the quantum library.
       // - The user does not input a qubit object in the node.
@@ -69,18 +70,16 @@ module.exports = function(RED) {
         }
 
         // Generate the corresponding CNot Gate Qiskit script
-        let cnotScript = '';
         node.qubits.map((msg) => {
           // Use qubits only if there are no registers.
           if (typeof msg.payload.register === 'undefined') {
-            cnotScript = util.format(
-                snippets.CNOT_GATE,
+            script += util.format(snippets.CNOT_GATE,
                 controlQubit.payload.qubit.toString(),
                 targetQubit.payload.qubit.toString(),
             );
           } else {
             // Use registers if there are quantum registers.
-            cnotScript = util.format(
+            script += util.format(
                 snippets.CNOT_GATE,
                 controlQubit.payload.registerVar + '[' +
                 controlQubit.payload.qubit.toString() + ']',
@@ -90,13 +89,12 @@ module.exports = function(RED) {
           }
         });
 
-        // Run the script in the python shell
-        await shell.execute(cnotScript, (err) => {
+        // Run the script in the python shell, and if no error occurs
+        // then send one qubit object per node output
+        await shell.execute(script, (err) => {
           if (err) node.error(err);
+          else send(node.qubits);
         });
-
-        // Sending one qubit object per node output
-        send(node.qubits);
       }
     });
   }

--- a/quantum/nodes/hadamard-gate/hadamard-gate.js
+++ b/quantum/nodes/hadamard-gate/hadamard-gate.js
@@ -10,6 +10,7 @@ module.exports = function(RED) {
     const node = this;
 
     node.on('input', async (msg, send, done) => {
+      let script = '';
       let qrConfig = msg.payload;
       let keys = Object.keys(qrConfig);
       if (!keys.includes('register') || !keys.includes('qubit')) {
@@ -22,14 +23,14 @@ module.exports = function(RED) {
         text: qrConfig.register ? `Register ${qrConfig.register} / Qubit ${qrConfig.qubit}` :
           `Qubit ${qrConfig.qubit}`,
       });
-      let shellScript = util.format(snippets.HADAMARD_GATE, qrConfig.register ?
-        `${qrConfig.register}[${qrConfig.qubit}]` :
-        `${qrConfig.qubit}`);
-      await shell.execute(shellScript, (err) => {
+      script += util.format(snippets.HADAMARD_GATE,
+        qrConfig.register ? `${qrConfig.register}[${qrConfig.qubit}]` : `${qrConfig.qubit}`);
+
+      // execute the script and pass the quantum register config to the output if no errors occurred
+      await shell.execute(script, (err) => {
         if (err) node.error(err);
+        else send(msg);
       });
-      // pass the quantum register config to the output
-      send(msg);
     });
   }
 

--- a/quantum/nodes/measurement/measurement.html
+++ b/quantum/nodes/measurement/measurement.html
@@ -20,7 +20,7 @@
     },
     inputs: 1,
     outputs: 1,
-    icon: "function.svg",
+    icon: "font-awesome/fa-tachometer",
     paletteLabel: "measurement",
     label: function () {
       return this.name || "measurement";

--- a/quantum/nodes/measurement/measurement.js
+++ b/quantum/nodes/measurement/measurement.js
@@ -17,21 +17,22 @@ module.exports = function(RED) {
     this.selectedBit = config.selectedBit;
     this.selectedRegVarName = config.selectedRegVarName;
     this.classicalRegistersOrBits = '';
-
     const node = this;
+
     this.on('input', async function(msg, send, done) {
+      let script = '';
       validateInput(node, msg);
       const params = (!node.selectedRegVarName) ? `${msg.payload.qubit}, ${node.selectedBit}`:
         `${msg.payload.registerVar}[${msg.payload.qubit}], ` +
         `${node.selectedRegVarName}[${node.selectedBit}]`;
 
-      const measureScript = util.format(snippets.MEASUREMENT, params);
-      await shell.execute(measureScript, (err) => {
-        if (err) {
-          node.error(err, msg);
-        }
+      script += util.format(snippets.MEASUREMENT, params);
+
+      await shell.execute(script, (err) => {
+        if (err) node.error(err);
+        else send(msg);
       });
-      send(msg);
+
       if (done) {
         done();
       }

--- a/quantum/nodes/measurement/measurement.js
+++ b/quantum/nodes/measurement/measurement.js
@@ -5,12 +5,13 @@ const snippets = require('../../snippets');
 const shell = require('../../python').PythonShell;
 const errors = require('../../errors');
 
+const validateInput = (node, msg) => {
+  if (msg.topic !== 'Quantum Circuit') {
+    node.error(errors.NOT_QUANTUM_CIRCUIT, msg);
+  }
+};
+
 module.exports = function(RED) {
-  const validateInput = (node, msg) => {
-    if (msg.topic !== 'Quantum Circuit') {
-      node.error(errors.NOT_QUANTUM_CIRCUIT, msg);
-    }
-  };
   function MeasurementNode(config) {
     RED.nodes.createNode(this, config);
     this.name = config.name;

--- a/quantum/nodes/measurement/measurement.js
+++ b/quantum/nodes/measurement/measurement.js
@@ -33,10 +33,6 @@ module.exports = function(RED) {
         if (err) node.error(err);
         else send(msg);
       });
-
-      if (done) {
-        done();
-      }
     });
   }
 

--- a/quantum/nodes/quantum-circuit/quantum-circuit.js
+++ b/quantum/nodes/quantum-circuit/quantum-circuit.js
@@ -21,10 +21,8 @@ module.exports = function(RED) {
     const node = this;
 
     this.on('input', async function(msg, send, done) {
-      await shell.restart();
-      await shell.execute(snippets.IMPORTS, (err) => {
-        if (err) node.error(err);
-      });
+      let script = '';
+      script += snippets.IMPORTS;
       // Creating a temporary 'quantumCircuitArray' flow context array
       // This variable represents the quantum circuit structure
       let quantumCircuitArray = new Array(node.outputs);
@@ -47,10 +45,7 @@ module.exports = function(RED) {
         };
       } else { // If the user does not want to use registers
         // Add arguments to quantum circuit code
-        let circuitScript = util.format(snippets.QUANTUM_CIRCUIT, node.qbitsreg + ',' + node.cbitsreg);
-        await shell.execute(circuitScript, (err) => {
-          if (err) node.error(err);
-        });
+        script += util.format(snippets.QUANTUM_CIRCUIT, node.qbitsreg + ',' + node.cbitsreg);
 
         // Creating an array of messages to be sent
         // Each message represents a different qubit
@@ -70,7 +65,11 @@ module.exports = function(RED) {
       }
 
       // Sending one register object per node output
-      send(output);
+      await shell.restart();
+      await shell.execute(script, (err) => {
+        if (err) node.error(err);
+        else send(output);
+      });
     });
   }
 

--- a/quantum/nodes/simulator/simulator.html
+++ b/quantum/nodes/simulator/simulator.html
@@ -1,14 +1,14 @@
 <script type="text/javascript">
   RED.nodes.registerType("simulator", {
     category: "quantum",
-    color: "#33B1FF",
+    color: "#C0C0C0",
     defaults: {
       name: { value: "" },
       shots: {value:0, validate:RED.validators.number()},
     },
     inputs: 1,
     outputs: 1,
-    icon: "function.svg",
+    icon: "font-awesome/fa-microchip",
     paletteLabel: "simulator",
     label: function () {
       return this.name || "simulator";

--- a/quantum/nodes/simulator/simulator.js
+++ b/quantum/nodes/simulator/simulator.js
@@ -20,6 +20,7 @@ module.exports = function(RED) {
     const node = this;
 
     this.on('input', async function(msg, send, done) {
+      let script = '';
       validateInput(node, msg);
       let qubitsArrived = true;
 
@@ -72,10 +73,11 @@ module.exports = function(RED) {
       // If all qubits have arrives, generate the simulator script and run it
       if (qubitsArrived) {
         const params = node.shots;
-        const simulatorScript = util.format(snippets.SIMULATOR, params);
-        await shell.execute(simulatorScript, (err, data) => {
+        script += util.format(snippets.SIMULATOR, params);
+        await shell.execute(script, (err, data) => {
+          node.error(shell.script);
           if (err) {
-            node.error(err, msg);
+            node.error(err);
           } else {
             msg.payload = data;
             send(msg);

--- a/quantum/nodes/simulator/simulator.js
+++ b/quantum/nodes/simulator/simulator.js
@@ -78,7 +78,7 @@ module.exports = function(RED) {
         const params = node.shots;
         script += util.format(snippets.SIMULATOR, params);
         await shell.execute(script, (err, data) => {
-          // node.error(shell.script);
+          node.error(shell.script);
           if (err) {
             node.error(err);
           } else {

--- a/quantum/nodes/simulator/simulator.js
+++ b/quantum/nodes/simulator/simulator.js
@@ -72,14 +72,17 @@ module.exports = function(RED) {
 
       // If all qubits have arrives, generate the simulator script and run it
       if (qubitsArrived) {
+        node.qubits = [];
+        node.qreg = '';
+
         const params = node.shots;
         script += util.format(snippets.SIMULATOR, params);
         await shell.execute(script, (err, data) => {
-          node.error(shell.script);
+          // node.error(shell.script);
           if (err) {
             node.error(err);
           } else {
-            msg.payload = data;
+            msg.payload = JSON.parse(data.replace(/'/g, '"'));
             send(msg);
           }
         });

--- a/quantum/python.js
+++ b/quantum/python.js
@@ -1,11 +1,13 @@
 'use strict';
 
+const os = require('os');
 const path = require('path');
 const appRoot = require('app-root-path').path;
 const dedent = require('dedent-js');
 const fileSystem = require('fs');
 const pythonScript = require('python-shell').PythonShell;
-const pythonPath = path.resolve(appRoot, 'venv/bin/python');
+const pythonExecutable = os.platform() === 'win32' ? 'venv/Scripts/python.exe' : 'venv/bin/python';
+const pythonPath = path.resolve(appRoot, pythonExecutable);
 const childProcess = require('child_process');
 
 

--- a/quantum/snippets.js
+++ b/quantum/snippets.js
@@ -14,40 +14,51 @@
 // worry about it later.
 const IMPORTS =
 `import numpy as np
- from qiskit import *`;
+ from qiskit import *
+ `;
 
 const QUANTUM_CIRCUIT =
-`qc = QuantumCircuit(%s)`;
+`qc = QuantumCircuit(%s)
+`;
 
 const CLASSICAL_REGISTER =
-`cr%s = ClassicalRegister(%s)`;
+`cr%s = ClassicalRegister(%s)
+`;
 
 const QUANTUM_REGISTER =
-`qr%s = QuantumRegister(%s)`;
+`qr%s = QuantumRegister(%s)
+`;
 
 const TOFFOLI_GATE =
-`qc.toffoli(%s, %s, %s)`;
+`qc.toffoli(%s, %s, %s)
+`;
 
 const CNOT_GATE =
-`qc.cx(%s, %s)`;
+`qc.cx(%s, %s)
+`;
 
 const BARRIER =
-`qc.barrier(%s)`;
+`qc.barrier(%s)
+`;
 
 const HADAMARD_GATE =
-`qc.h(%s)`;
+`qc.h(%s)
+`;
 
 const MEASUREMENT =
-`qc.measure(%s)`;
+`qc.measure(%s)
+`;
 
 const SIMULATOR =
 `simulator = Aer.get_backend('qasm_simulator')
 result = execute(qc, backend = simulator, shots = %s).result()
 counts = result.get_counts()
-print(counts)`;
+print(counts)
+`;
 
 const NOT_GATE =
-`qc.x(%s)`;
+`qc.x(%s)
+`;
 
 module.exports = {
   IMPORTS,


### PR DESCRIPTION
### Purpose
Fix for the execution of parallel nodes. Note that this fix is somewhat rudimentary, but it works for now and we can implement a more concrete fix later on.

### Changes
- Fix issue #28 (c1805044c0db4c4089bf787db767d53e9880e639).
- Fix issue #21 (5f0cec93a27048eef5aaf45fa5314ae0ad639c06 & 202f8615929637349cd25bbbebbbc1999a8fc17a).

### New Requirements
Nodes can only contain a single `shell.execute()` statement - any more than that and it breaks. This shouldn't be much of a problem since we only need one execute statement per node anyway, and we still get the benefit of identifying which node gave an error. I have updated all the current nodes to reflect this change.

I've also added a newline to the end of each snippet (b457d5b4a092d9348db83e68db327b52e5afb6a8). The reason for this is that it makes concatenation of snippet strings consistent and easier, for example:
- Given the snippet:
  ```node
  const QUANTUM_CIRCUIT =
  `qc = QuantumCircuit(%s)`;
  ```
  We would need to write `script += snippets.QUANTUM_CIRCUIT + '\n';`

- Given the snippet:
  ```node
  const QUANTUM_CIRCUIT =
  `qc = QuantumCircuit(%s)
  `;
  ```
  We would need to write `script += snippets.QUANTUM_CIRCUIT;`

Doing this for snippets should be maintained as it's safer for avoiding bugs, since we can always be sure that a code block has been ended with a line break without having to manually do it every time.