### PR TITLE
Deleting runtime storage variables upon output

### DIFF
--- a/quantum/nodes/barrier/barrier.js
+++ b/quantum/nodes/barrier/barrier.js
@@ -74,7 +74,12 @@ module.exports = function(RED) {
         // then send one qubit object per node output
         await shell.execute(script, (err) => {
           if (err) node.error(err);
-          else send(node.qubits);
+          else {
+            send(node.qubits);
+
+            // Emptying the runtime variable upon output
+            node.qubits = [];
+          }
         });
       }
     });

--- a/quantum/nodes/cnot-gate/cnot-gate.js
+++ b/quantum/nodes/cnot-gate/cnot-gate.js
@@ -93,7 +93,12 @@ module.exports = function(RED) {
         // then send one qubit object per node output
         await shell.execute(script, (err) => {
           if (err) node.error(err);
-          else send(node.qubits);
+          else {
+            send(node.qubits);
+
+            // Emptying the runtime variable upon output
+            node.qubits = [];
+          }
         });
       }
     });

--- a/quantum/nodes/simulator/simulator.js
+++ b/quantum/nodes/simulator/simulator.js
@@ -72,6 +72,7 @@ module.exports = function(RED) {
 
       // If all qubits have arrives, generate the simulator script and run it
       if (qubitsArrived) {
+        // Emptying the runtime variables upon output
         node.qubits = [];
         node.qreg = '';
 

--- a/quantum/nodes/toffoli-gate/toffoli-gate.js
+++ b/quantum/nodes/toffoli-gate/toffoli-gate.js
@@ -110,7 +110,12 @@ module.exports = function(RED) {
         // then send one qubit object per node output
         await shell.execute(script, (err) => {
           if (err) node.error(err);
-          else send(node.qubits);
+          else {
+            send(node.qubits);
+
+            // Emptying the runtime variable upon output
+            node.qubits = [];
+          }
         });
       }
     });


### PR DESCRIPTION
### Purpose
When nodes store runtime data (especially qubits) during runtime, the variable used to store should be emptied upon sending the output to the next node. 

This will allow the user to run the same circuit multiple times successively, otherwise, we would get inconsistent states.

### Changes
`node.qubits = []` after `node.send(node.qubits)`