### PR TITLE
Theo/identity and qubit nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
       "qubit": "quantum/nodes/qubit/qubit.js",
       "simulator": "quantum/nodes/simulator/simulator.js",
       "cnot-gate": "quantum/nodes/cnot-gate/cnot-gate.js",
-      "hadamard-gate": "quantum/nodes/hadamard-gate/hadamard-gate.js"
+      "hadamard-gate": "quantum/nodes/hadamard-gate/hadamard-gate.js",
+      "identity": "quantum/nodes/identity/identity.js"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
       "not-gate": "quantum/nodes/not-gate/not-gate.js",
       "measurement": "quantum/nodes/measurement/measurement.js",
       "barrier": "quantum/nodes/barrier/barrier.js",
-      "identity": "quantum/nodes/identity/identity.js",
+      "qubit": "quantum/nodes/qubit/qubit.js",
       "simulator": "quantum/nodes/simulator/simulator.js",
       "cnot-gate": "quantum/nodes/cnot-gate/cnot-gate.js",
       "hadamard-gate": "quantum/nodes/hadamard-gate/hadamard-gate.js"

--- a/quantum/nodes/identity/identity.html
+++ b/quantum/nodes/identity/identity.html
@@ -1,0 +1,32 @@
+<script type="text/javascript">
+  RED.nodes.registerType("identity", {
+    category: "quantum",
+    color: "#FA4D56",
+    defaults: {
+      name: { value: "" },
+    },
+    inputs: 1,
+    outputs: 1,
+    paletteLabel: "identity",
+    icon: "font-awesome/fa-close",
+    align: 'right',
+    label: function () {
+      return this.name || "identity";
+    },
+    inputLabels = "Qubit",
+    outputLabels = "Qubit",
+  });
+</script>
+
+<script type="text/html" data-template-name="identity">
+  <div class="form-row">
+    <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+    <input type="text" id="node-input-name" placeholder="Name" />
+  </div>
+</script>
+
+<script type="text/html" data-help-name="identity">
+  <p>
+    <!-- Node documentation goes here. -->
+  </p>
+</script>

--- a/quantum/nodes/identity/identity.html
+++ b/quantum/nodes/identity/identity.html
@@ -8,7 +8,7 @@
     inputs: 1,
     outputs: 1,
     paletteLabel: "identity",
-    icon: "font-awesome/fa-close",
+    icon: "font-awesome/fa-i-cursor",
     align: 'right',
     label: function () {
       return this.name || "identity";

--- a/quantum/nodes/identity/identity.html
+++ b/quantum/nodes/identity/identity.html
@@ -13,8 +13,8 @@
     label: function () {
       return this.name || "identity";
     },
-    inputLabels = "Qubit",
-    outputLabels = "Qubit",
+    inputLabels: "Qubit",
+    outputLabels: "Qubit",
   });
 </script>
 

--- a/quantum/nodes/identity/identity.js
+++ b/quantum/nodes/identity/identity.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const util = require('util');
+const snippets = require('../../snippets');
+const shell = require('../../python').PythonShell;
+
+module.exports = function(RED) {
+  function IdentityNode(config) {
+    RED.nodes.createNode(this, config);
+    this.name = config.name;
+    const node = this;
+
+    this.on('input', async function(msg, send, done) {
+      let script = '';
+      // Thorw error if:
+      // - The user connects it to a node that is not from the quantum library
+      // - The user does not input a qubit object in the node
+      // - the user chooses to use registers but does not initiate them
+      if (msg.topic !== 'Quantum Circuit') {
+        throw new Error(
+            'The Identity gate node must be connected to nodes from the quantum library only.',
+        );
+      } else if (
+        typeof msg.payload.register === 'undefined' &&
+        typeof msg.payload.qubit === 'undefined'
+      ) {
+        throw new Error(
+            'The Identity gate node must be receive qubits objects as inputs.\n' +
+            'Please use "Quantum Circut" and "Quantum Register" node to generate qubits objects.',
+        );
+      } else if (
+        typeof msg.payload.qubit === 'undefined'
+      ) {
+        throw new Error(
+            'If "Registers & Bits" was selected in the "Quantum Circuit" node, please make use of register nodes.',
+        );
+      }
+
+      if (typeof msg.payload.register === 'undefined') {
+        script += util.format(snippets.IDENTITY, msg.payload.qubit);
+      } else {
+        script += util.format(snippets.IDENTITY, `msg.payload.registerVar + '[' + msg.payload.qubit + ']'`);
+      }
+
+      // Run the script in the python shell, and if no error occurs
+      // then send msg object to the next node
+      await shell.execute(script, (err) => {
+        if (err) node.error(err);
+        else send(msg);
+      });
+    });
+  }
+  RED.nodes.registerType('identity', IdentityNode);
+};

--- a/quantum/nodes/not-gate/not-gate.html
+++ b/quantum/nodes/not-gate/not-gate.html
@@ -23,6 +23,8 @@
     <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
     <input type="text" id="node-input-name" placeholder="Name" />
   </div>
+</script>
+
 <script type="text/html" data-help-name="not-gate">
   <p>
     <!-- Node documentation goes here. -->

--- a/quantum/nodes/not-gate/not-gate.html
+++ b/quantum/nodes/not-gate/not-gate.html
@@ -13,8 +13,8 @@
     label: function () {
       return this.name || "not";
     },
-    inputLabels = "Qubit",
-    outputLabels = "Qubit",
+    inputLabels: "Qubit",
+    outputLabels: "Qubit",
   });
 </script>
 

--- a/quantum/nodes/not-gate/not-gate.js
+++ b/quantum/nodes/not-gate/not-gate.js
@@ -25,7 +25,7 @@ module.exports = function(RED) {
         typeof msg.payload.qubit === 'undefined'
       ) {
         throw new Error(
-            'The Node Gate node must be receive qubits objects as inputs.\n' +
+            'The Not Gate node must be receive qubits objects as inputs.\n' +
             'Please use "Quantum Circut" and "Quantum Register" node to generate qubits objects.',
         );
       } else if (

--- a/quantum/nodes/qubit/qubit.html
+++ b/quantum/nodes/qubit/qubit.html
@@ -1,5 +1,5 @@
 <script type="text/javascript">
-    RED.nodes.registerType("identity", {
+    RED.nodes.registerType("qubit", {
       category: "quantum",
       color: "#C7E9C0",
       defaults: {
@@ -9,23 +9,23 @@
       inputs: 1,
       icon: "font-awesome/fa-chevron-right",
       align: 'left',
-      paletteLabel: "identity",
+      paletteLabel: "qubit",
       label: function () {
-        return this.name || "identity";
+        return this.name || "qubit";
       },
       inputLabels: "Qubit",
       outputLabels: "Qubit",
     });
   </script>
   
-  <script type="text/html" data-template-name="identity">
+  <script type="text/html" data-template-name="qubit">
     <div class="form-row">
       <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
       <input type="text" id="node-input-name" placeholder="Name" />
     </div>
   </script>
   
-  <script type="text/html" data-help-name="identity">
+  <script type="text/html" data-help-name="qubit">
     <p>
       <!-- Node documentation goes here. -->
     </p>

--- a/quantum/nodes/qubit/qubit.js
+++ b/quantum/nodes/qubit/qubit.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function(RED) {
-  function IdentityNode(config) {
+  function QubitNode(config) {
     // Creating node with properties
     RED.nodes.createNode(this, config);
     this.name = config.name;
@@ -14,11 +14,11 @@ module.exports = function(RED) {
       // - The user chooses to use registers but does not initiate them
       if (msg.topic !== 'Quantum Circuit') {
         throw new Error(
-            'Identity gates must be connected to nodes from the quantum library only.',
+            'Qubit nodes must be connected to nodes from the quantum library only.',
         );
       } else if (typeof(msg.payload.register) === 'undefined' && typeof(msg.payload.qubit) === 'undefined') {
         throw new Error(
-            'Identity gates must receive qubits objects as inputs.\n' +
+            'Qubit nodes must receive qubits objects as inputs.\n' +
             'Please use "Quantum Circuit" & "Quantum Register" nodes to generate qubits objects.',
         );
       } else if (typeof(msg.payload.qubit) === 'undefined') {
@@ -47,5 +47,5 @@ module.exports = function(RED) {
     });
   }
 
-  RED.nodes.registerType('identity', IdentityNode);
+  RED.nodes.registerType('qubit', QubitNode);
 };

--- a/quantum/snippets.js
+++ b/quantum/snippets.js
@@ -60,6 +60,10 @@ const NOT_GATE =
 `qc.x(%s)
 `;
 
+const IDENTITY =
+`qc.id(%s)
+`;
+
 module.exports = {
   IMPORTS,
   QUANTUM_CIRCUIT,
@@ -72,4 +76,5 @@ module.exports = {
   MEASUREMENT,
   SIMULATOR,
   NOT_GATE,
+  IDENTITY,
 };


### PR DESCRIPTION
### Purpose
To avoid any misunderstanding and improve Node-RED Quantum completeness, made some changes to the 'identity' node that was not applying any gate to the circuit. The palette makes more sense now.

### Changes
- Renamed the 'identity' node to 'qubit': this node will be used to identify which qubit is which in big circuits using the node status.
- Added a proper 'identity' node for completeness: adds an identity gate to the quantum circuit (no effect on circuit, like (+0) or (x1))
