### PR TITLE
Fixed issue #39 by removing an extra iteration

### DIFF
--- a/quantum/nodes/cnot-gate/cnot-gate.js
+++ b/quantum/nodes/cnot-gate/cnot-gate.js
@@ -70,24 +70,22 @@ module.exports = function(RED) {
         }
 
         // Generate the corresponding CNot Gate Qiskit script
-        node.qubits.map((msg) => {
-          // Use qubits only if there are no registers.
-          if (typeof msg.payload.register === 'undefined') {
-            script += util.format(snippets.CNOT_GATE,
-                controlQubit.payload.qubit.toString(),
-                targetQubit.payload.qubit.toString(),
-            );
-          } else {
-            // Use registers if there are quantum registers.
-            script += util.format(
-                snippets.CNOT_GATE,
-                controlQubit.payload.registerVar + '[' +
-                controlQubit.payload.qubit.toString() + ']',
-                targetQubit.payload.registerVar + '[' +
-                targetQubit.payload.qubit.toString() + ']',
-            );
-          }
-        });
+        // Use qubits only if there are no registers.
+        if (typeof msg.payload.register === 'undefined') {
+          script += util.format(snippets.CNOT_GATE,
+              controlQubit.payload.qubit.toString(),
+              targetQubit.payload.qubit.toString(),
+          );
+        } else {
+          // Use registers if there are quantum registers.
+          script += util.format(
+              snippets.CNOT_GATE,
+              controlQubit.payload.registerVar + '[' +
+              controlQubit.payload.qubit.toString() + ']',
+              targetQubit.payload.registerVar + '[' +
+              targetQubit.payload.qubit.toString() + ']',
+          );
+        }
 
         // Run the script in the python shell, and if no error occurs
         // then send one qubit object per node output

--- a/quantum/nodes/toffoli-gate/toffoli-gate.js
+++ b/quantum/nodes/toffoli-gate/toffoli-gate.js
@@ -76,35 +76,32 @@ module.exports = function(RED) {
           control2 = node.qubits[1];
         }
 
-        // Generate the corresponding Toffoli Gate Qiskit script
-        node.qubits.map((msg) => {
-          // Use qubits only if there are no registers.
-          if (typeof msg.payload.register === 'undefined') {
-            script += util.format(
-                snippets.TOFFOLI_GATE,
-                control1.payload.qubit.toString(),
-                control2.payload.qubit.toString(),
-                target.payload.qubit.toString(),
-            );
-          } else {
-            // Use registers if there are quantum registers.
-            script += util.format(
-                snippets.TOFFOLI_GATE,
-                control1.payload.registerVar +
-                '[' +
-                control1.payload.qubit.toString() +
-                ']',
-                control2.payload.registerVar +
-                '[' +
-                control2.payload.qubit.toString() +
-                ']',
-                target.payload.registerVar +
-                '[' +
-                target.payload.qubit.toString() +
-                ']',
-            );
-          }
-        });
+        // Use qubits only if there are no registers.
+        if (typeof msg.payload.register === 'undefined') {
+          script += util.format(
+              snippets.TOFFOLI_GATE,
+              control1.payload.qubit.toString(),
+              control2.payload.qubit.toString(),
+              target.payload.qubit.toString(),
+          );
+        } else {
+          // Use registers if there are quantum registers.
+          script += util.format(
+              snippets.TOFFOLI_GATE,
+              control1.payload.registerVar +
+              '[' +
+              control1.payload.qubit.toString() +
+              ']',
+              control2.payload.registerVar +
+              '[' +
+              control2.payload.qubit.toString() +
+              ']',
+              target.payload.registerVar +
+              '[' +
+              target.payload.qubit.toString() +
+              ']',
+          );
+        }
 
         // Run the script in the python shell, and if no error occurs
         // then send one qubit object per node output


### PR DESCRIPTION
### Purpose
Fix issue #39 where multiple qubit gates were writing their script multiple times to the script variable.


### Changes
Removed an extra iteration that resulted in 2 or 3 scripts being generated: `node.qubits.map(...)`




Closes #39 