### PR TITLE
Theo/Nodes input validation & error handling

### DIFF
--- a/quantum/errors.js
+++ b/quantum/errors.js
@@ -42,14 +42,9 @@ function validateRegisterInput(msg) {
         'To use "Quantum Register" & "Classical Register" nodes, ' +
         'please select "Registers & Bits" in the "Quantum Circuit" node properties.',
     );
-  } else if ( (keys.includes('register') && typeof msg.payload.register !== 'number') || keys.includes('qubit')) {
+  } else if ((keys.includes('register') && typeof msg.payload.register !== 'number') || keys.includes('qubit')) {
     throw new Error(
-        
-      
-      'This node must receive qubits objects as inputs.\n' +
-        'To generate qubits objects, please make use of the "Quantum Circuit" node.',
-
-        
+        'This node must be connected to the outputs of the "Quantum Circuit" node.',
     );
   }
 };

--- a/quantum/errors.js
+++ b/quantum/errors.js
@@ -50,7 +50,22 @@ function validateRegisterInput(node, msg) {
   }
 };
 
+function validateQubitsFromSameCircuit(node, qubits) {
+  let circuitId = qubits[0].payload.structure.quantumCircuitId;
+  let valid = qubits.every((obj) => obj.payload.structure.quantumCircuitId === circuitId);
+  if (!valid) node.error('Only qubits from the same quantum circuit should be connected to this node.');
+};
+
+const INVALID_REGISTER_NUMBER =
+'Please input the correct number of quantum & classical registers in the "Quantum Circuit" node properties.';
+
+const QUBITS_FROM_DIFFERENT_CIRCUITS =
+'Only qubits from the same quantum circuit should be connected to this node.';
+
 module.exports = {
   validateQubitInput,
   validateRegisterInput,
+  validateQubitsFromSameCircuit,
+  INVALID_REGISTER_NUMBER,
+  QUBITS_FROM_DIFFERENT_CIRCUITS,
 };

--- a/quantum/errors.js
+++ b/quantum/errors.js
@@ -1,3 +1,60 @@
+'use strict';
+
+/*
+ * Node-RED nodes error handling functions should be defined here for homogeneity and reuse.
+ *
+ * Remember to export these validation functions at the end of the file.
+ *
+ * To use values from JavaScript code within an error message, insert a '%s' where you want
+ * to place the values. You can then use the util.format() function to replace them with
+ * the values at runtime.
+ */
+
+function validateQubitInput(msg) {
+  let keys = Object.keys(msg.payload);
+
+  if (msg.topic !== 'Quantum Circuit') {
+    throw new Error(
+        'This node must be connected to nodes from the "Node-RED Quantum" library only.',
+    );
+  } else if (keys.includes('register') && typeof msg.payload.register === 'number') {
+    throw new Error(
+        'If "Registers & Bits" was selected in the "Quantum Circuit" node properties, ' +
+        'please connect "Quantum Register" & "Classical Register" nodes to the "Quantum Circuit" node outputs.',
+    );
+  } else if (!keys.includes('register') || !keys.includes('qubit') || !keys.includes('structure')) {
+    throw new Error(
+        'This node must receive qubits objects as inputs.\n' +
+        'To generate qubits objects, please make use of the "Quantum Circuit" node.',
+    );
+  }
+};
+
+function validateRegisterInput(msg) {
+  let keys = Object.keys(msg.payload);
+
+  if (msg.topic !== 'Quantum Circuit') {
+    throw new Error(
+        'This node must be connected to nodes from the "Node-RED Quantum" library only.',
+    );
+  } else if (keys.includes('register') && typeof msg.payload.register === 'undefined') {
+    throw new Error(
+        'To use "Quantum Register" & "Classical Register" nodes, ' +
+        'please select "Registers & Bits" in the "Quantum Circuit" node properties.',
+    );
+  } else if ( (keys.includes('register') && typeof msg.payload.register !== 'number') || keys.includes('qubit')) {
+    throw new Error(
+        
+      
+      'This node must receive qubits objects as inputs.\n' +
+        'To generate qubits objects, please make use of the "Quantum Circuit" node.',
+
+        
+    );
+  }
+};
+
 module.exports = {
-  NOT_QUANTUM_CIRCUIT: 'Node must be connected to nodes from the quantum library only',
+  validateQubitInput,
+  validateRegisterInput,
 };

--- a/quantum/errors.js
+++ b/quantum/errors.js
@@ -10,41 +10,42 @@
  * the values at runtime.
  */
 
-function validateQubitInput(msg) {
+function validateQubitInput(node, msg) {
   let keys = Object.keys(msg.payload);
 
   if (msg.topic !== 'Quantum Circuit') {
-    throw new Error(
+    node.error(
         'This node must be connected to nodes from the "Node-RED Quantum" library only.',
     );
   } else if (keys.includes('register') && typeof msg.payload.register === 'number') {
-    throw new Error(
+    node.error(
         'If "Registers & Bits" was selected in the "Quantum Circuit" node properties, ' +
         'please connect "Quantum Register" & "Classical Register" nodes to the "Quantum Circuit" node outputs.',
     );
   } else if (!keys.includes('register') || !keys.includes('qubit') || !keys.includes('structure')) {
-    throw new Error(
+    node.error(
         'This node must receive qubits objects as inputs.\n' +
         'To generate qubits objects, please make use of the "Quantum Circuit" node.',
     );
   }
 };
 
-function validateRegisterInput(msg) {
+function validateRegisterInput(node, msg) {
   let keys = Object.keys(msg.payload);
 
   if (msg.topic !== 'Quantum Circuit') {
-    throw new Error(
+    node.error(
         'This node must be connected to nodes from the "Node-RED Quantum" library only.',
     );
   } else if (keys.includes('register') && typeof msg.payload.register === 'undefined') {
-    throw new Error(
+    node.error(
         'To use "Quantum Register" & "Classical Register" nodes, ' +
         'please select "Registers & Bits" in the "Quantum Circuit" node properties.',
     );
   } else if ((keys.includes('register') && typeof msg.payload.register !== 'number') || keys.includes('qubit')) {
-    throw new Error(
-        'This node must be connected to the outputs of the "Quantum Circuit" node.',
+    node.error(
+        'This node must receive register objects as inputs.\n' +
+        'Please connect it to the outputs of the "Quantum Circuit" node.',
     );
   }
 };

--- a/quantum/nodes/barrier/barrier.js
+++ b/quantum/nodes/barrier/barrier.js
@@ -26,6 +26,9 @@ module.exports = function(RED) {
 
       // If all qubits have arrived, we first reorder the node.qubits array for output consistency
       if (node.qubits.length == node.outputs) {
+        // Checking that all qubits received as input are from the same quantum circuit
+        errors.validateQubitsFromSameCircuit(node, node.qubits);
+
         node.qubits.sort(function compare(a, b) {
           if (typeof(a.payload.register) !== 'undefined') {
             const regA = parseInt(a.payload.registerVar.slice(2));

--- a/quantum/nodes/barrier/barrier.js
+++ b/quantum/nodes/barrier/barrier.js
@@ -3,6 +3,7 @@
 const util = require('util');
 const snippets = require('../../snippets');
 const shell = require('../../python').PythonShell;
+const errors = require('../../errors');
 
 module.exports = function(RED) {
   function BarrierNode(config) {
@@ -15,29 +16,10 @@ module.exports = function(RED) {
 
     this.on('input', async function(msg, send, done) {
       let script = '';
-      // Throw a connection error if:
-      // - The user connects it to a node that is not from the quantum library
-      // - The user does not input a qubit object in the node
-      // - The user chooses to use registers but does not initiate them
-      // - The user inputs more qubits than selected in the node properties
-      if (msg.topic !== 'Quantum Circuit') {
-        throw new Error(
-            'Quantum barrier nodes must be connected to nodes from the quantum library only.',
-        );
-      } else if (typeof(msg.payload.register) === 'undefined' && typeof(msg.payload.qubit) === 'undefined') {
-        throw new Error(
-            'Quantum barrier nodes must receive qubits objects as inputs.\n' +
-            'Please use "Quantum Circuit" & "Quantum Register" nodes to generate qubits objects.',
-        );
-      } else if (typeof(msg.payload.qubit) === 'undefined') {
-        throw new Error(
-            'If "Registers & Bits" was selected in the "Quantum Circuit" node, please make use of register nodes.',
-        );
-      } else if (node.qubits.length >= node.outputs) {
-        throw new Error(
-            'Please inputs the same number of qubits than selected in the node properties.',
-        );
-      }
+
+      // Validate the node input msg: check for qubit object.
+      // Throw corresponding errors if required.
+      errors.validateQubitInput(node, msg);
 
       // Store all the qubit objects received as input into the node.qubits array
       node.qubits.push(msg);

--- a/quantum/nodes/barrier/barrier.js
+++ b/quantum/nodes/barrier/barrier.js
@@ -18,8 +18,13 @@ module.exports = function(RED) {
       let script = '';
 
       // Validate the node input msg: check for qubit object.
-      // Throw corresponding errors if required.
-      errors.validateQubitInput(node, msg);
+      // Return corresponding errors or null if no errors.
+      // Stop the node execution upon an error
+      let error = errors.validateQubitInput(msg);
+      if (error) {
+        done(error);
+        return;
+      }
 
       // Store all the qubit objects received as input into the node.qubits array
       node.qubits.push(msg);
@@ -27,7 +32,11 @@ module.exports = function(RED) {
       // If all qubits have arrived, we first reorder the node.qubits array for output consistency
       if (node.qubits.length == node.outputs) {
         // Checking that all qubits received as input are from the same quantum circuit
-        errors.validateQubitsFromSameCircuit(node, node.qubits);
+        let error = errors.validateQubitsFromSameCircuit(node.qubits);
+        if (error) {
+          done(error);
+          return;
+        }
 
         node.qubits.sort(function compare(a, b) {
           if (typeof(a.payload.register) !== 'undefined') {
@@ -58,12 +67,11 @@ module.exports = function(RED) {
         // Run the script in the python shell, and if no error occurs
         // then send one qubit object per node output
         await shell.execute(script, (err) => {
-          if (err) node.error(err);
+          if (err) done(err);
           else {
             send(node.qubits);
-
-            // Emptying the runtime variable upon output
-            node.qubits = [];
+            node.qubits = []; // Emptying the runtime variable upon output
+            done();
           }
         });
       }

--- a/quantum/nodes/classical-register/classical-register.js
+++ b/quantum/nodes/classical-register/classical-register.js
@@ -3,6 +3,7 @@
 const util = require('util');
 const snippets = require('../../snippets');
 const shell = require('../../python').PythonShell;
+const errors = require('../../errors');
 
 module.exports = function(RED) {
   function ClassicalRegisterNode(config) {
@@ -15,23 +16,10 @@ module.exports = function(RED) {
 
     this.on('input', async function(msg, send, done) {
       let script = '';
-      // Throw a connection error if:
-      // - The user connects it to a node that is not from the quantum library
-      // - The user did not select the 'Registers & Bits' option in the 'Quantum Circuit' node
-      // - The user does not connect the register node to the output of the 'Quantum Circuit' node
-      if (msg.topic !== 'Quantum Circuit') {
-        throw new Error(
-            'Register nodes must be connected to nodes from the quantum library only',
-        );
-      } else if (typeof(msg.payload.register) === 'undefined') {
-        throw new Error(
-            'Select "Registers & Qubits" in the "Quantum Circuit" node properties to use registers.',
-        );
-      } else if (typeof(msg.payload.register) !== 'number') {
-        throw new Error(
-            'Register nodes must be connected to the outputs of the "Quantum Circuit" node.',
-        );
-      }
+
+      // Validate the node input msg: check for register object.
+      // Throw corresponding errors if required.
+      errors.validateRegisterInput(node, msg);
 
       // Add arguments to classical register code
       script += util.format(snippets.CLASSICAL_REGISTER,

--- a/quantum/nodes/classical-register/classical-register.js
+++ b/quantum/nodes/classical-register/classical-register.js
@@ -18,8 +18,13 @@ module.exports = function(RED) {
       let script = '';
 
       // Validate the node input msg: check for register object.
-      // Throw corresponding errors if required.
-      errors.validateRegisterInput(node, msg);
+      // Return corresponding errors or null if no errors.
+      // Stop the node execution upon an error
+      let error = errors.validateRegisterInput(msg);
+      if (error) {
+        done(error);
+        return;
+      }
 
       // Add arguments to classical register code
       script += util.format(snippets.CLASSICAL_REGISTER,
@@ -37,28 +42,19 @@ module.exports = function(RED) {
 
       // If the quantum circuit has not yet been initialised by another register
       if (typeof(flowContext.get('quantumCircuit')) !== undefined) {
-        // Counting the number of registers that were set in the 'quantumCircuit' array
         let structure = flowContext.get('quantumCircuit');
 
-        let count = 0;
-        let qreg = 0;
-        let creg = 0;
-        structure.map((x) => {
-          if (typeof(x) !== 'undefined') {
-            count += 1;
-            if (x.registerType === 'quantum') qreg += 1;
-            else creg += 1;
-          }
-        });
+        // Validating the registers' structure according to the user input in 'Quantum Circuit'
+        // And counting how many registers were initialised so far.
+        let [error, count] = errors.validateRegisterStrucutre(structure, msg.payload.structure);
+        if (error) {
+          done(error);
+          return;
+        }
 
-        // If the user specified a register structure in the 'Quantum Circuit' node that
-        // does not match the visual structure built using the register nodes, throw an error
-        if (qreg > msg.payload.structure.qreg || creg > msg.payload.structure.creg) {
-          node.error(errors.INVALID_REGISTER_NUMBER);
-
-        // If all set & the quantum circuit has not yet been initialised by another register:
+        // If all register initialised & the circuit has not been initialised by another register:
         // Initialise the quantum circuit
-        } else if (count == structure.length && typeof(flowContext.get('quantumCircuit')) !== undefined) {
+        if (count == structure.length && typeof(flowContext.get('quantumCircuit')) !== undefined) {
           // Delete the 'quantumCircuit' flow context variable, not used anymore
           flowContext.set('quantumCircuit', undefined);
 
@@ -76,7 +72,7 @@ module.exports = function(RED) {
       // Run the script in the python shell, and if no error occurs
       // then notify the runtime when the node is done.
       await shell.execute(script, (err) => {
-        if (err) node.error(err);
+        if (err) done(err);
         else done();
       });
     });

--- a/quantum/nodes/classical-register/classical-register.js
+++ b/quantum/nodes/classical-register/classical-register.js
@@ -54,9 +54,7 @@ module.exports = function(RED) {
         // If the user specified a register structure in the 'Quantum Circuit' node that
         // does not match the visual structure built using the register nodes, throw an error
         if (qreg > msg.payload.structure.qreg || creg > msg.payload.structure.creg) {
-          throw new Error(
-              'Please enter the correct number of quantum & classical registers in the "Quantum Circuit" node.',
-          );
+          node.error(errors.INVALID_REGISTER_NUMBER);
 
         // If all set & the quantum circuit has not yet been initialised by another register:
         // Initialise the quantum circuit

--- a/quantum/nodes/cnot-gate/cnot-gate.js
+++ b/quantum/nodes/cnot-gate/cnot-gate.js
@@ -2,6 +2,7 @@
 const util = require('util');
 const snippets = require('../../snippets');
 const shell = require('../../python').PythonShell;
+const errors = require('../../errors');
 
 module.exports = function(RED) {
   function CNotGateNode(config) {
@@ -13,27 +14,10 @@ module.exports = function(RED) {
 
     this.on('input', async function(msg, send, done) {
       let script = '';
-      // Throw a connection error if:
-      // - The user connects it to a node that is not from the quantum library.
-      // - The user does not input a qubit object in the node.
-      // - The user chooses to use registers but does not initiate them.
-      if (msg.topic !== 'Quantum Circuit') {
-        throw new Error(
-            'The CNot Gate must be connected to nodes from the quantum library only.',
-        );
-      } else if (
-        typeof msg.payload.register === 'undefined' &&
-        typeof msg.payload.qubit === 'undefined'
-      ) {
-        throw new Error(
-            'The CNot Gate nodes must receive qubits objects as inputs.\n' +
-            'Please use "Quantum Circuit" & "Quantum Register" nodes to generate qubits objects.',
-        );
-      } else if (typeof msg.payload.qubit === 'undefined') {
-        throw new Error(
-            'If "Registers & Bits" was selected in the "Quantum Circuit" node, please make use of register nodes.',
-        );
-      }
+
+      // Validate the node input msg: check for qubit object.
+      // Throw corresponding errors if required.
+      errors.validateQubitInput(node, msg);
 
       // Store all the qubit objects received as input into the node.qubits array
       node.qubits.push(msg);

--- a/quantum/nodes/cnot-gate/cnot-gate.js
+++ b/quantum/nodes/cnot-gate/cnot-gate.js
@@ -24,6 +24,9 @@ module.exports = function(RED) {
 
       // If all qubits have arrived, we first reorder the node.qubits array for output consistency
       if (node.qubits.length == 2) {
+        // Checking that all qubits received as input are from the same quantum circuit
+        errors.validateQubitsFromSameCircuit(node, node.qubits);
+
         node.qubits.sort(function compare(a, b) {
           if (typeof a.payload.register !== 'undefined') {
             const regA = parseInt(a.payload.registerVar.slice(2));

--- a/quantum/nodes/hadamard-gate/hadamard-gate.js
+++ b/quantum/nodes/hadamard-gate/hadamard-gate.js
@@ -14,8 +14,13 @@ module.exports = function(RED) {
       let script = '';
 
       // Validate the node input msg: check for qubit object.
-      // Throw corresponding errors if required.
-      errors.validateQubitInput(node, msg);
+      // Return corresponding errors or null if no errors.
+      // Stop the node execution upon an error
+      let error = errors.validateQubitInput(msg);
+      if (error) {
+        done(error);
+        return;
+      }
 
       let qrConfig = msg.payload;
       script += util.format(snippets.HADAMARD_GATE,
@@ -23,8 +28,11 @@ module.exports = function(RED) {
 
       // execute the script and pass the quantum register config to the output if no errors occurred
       await shell.execute(script, (err) => {
-        if (err) node.error(err);
-        else send(msg);
+        if (err) done(err);
+        else {
+          send(msg);
+          done();
+        }
       });
     });
   }

--- a/quantum/nodes/hadamard-gate/hadamard-gate.js
+++ b/quantum/nodes/hadamard-gate/hadamard-gate.js
@@ -3,6 +3,7 @@
 const util = require('util');
 const snippets = require('../../snippets');
 const shell = require('../../python').PythonShell;
+const errors = require('../../errors');
 
 module.exports = function(RED) {
   function HadamardGateNode(config) {
@@ -11,12 +12,12 @@ module.exports = function(RED) {
 
     node.on('input', async (msg, send, done) => {
       let script = '';
-      let qrConfig = msg.payload;
-      let keys = Object.keys(qrConfig);
-      if (!keys.includes('register') || !keys.includes('qubit')) {
-        throw new Error('Invalid Input');
-      }
 
+      // Validate the node input msg: check for qubit object.
+      // Throw corresponding errors if required.
+      errors.validateQubitInput(node, msg);
+
+      let qrConfig = msg.payload;
       script += util.format(snippets.HADAMARD_GATE,
         qrConfig.register ? `${qrConfig.register}[${qrConfig.qubit}]` : `${qrConfig.qubit}`);
 

--- a/quantum/nodes/identity-gate/identity-gate.js
+++ b/quantum/nodes/identity-gate/identity-gate.js
@@ -3,6 +3,7 @@
 const util = require('util');
 const snippets = require('../../snippets');
 const shell = require('../../python').PythonShell;
+const errors = require('../../errors');
 
 module.exports = function(RED) {
   function IdentityGateNode(config) {
@@ -12,29 +13,10 @@ module.exports = function(RED) {
 
     this.on('input', async function(msg, send, done) {
       let script = '';
-      // Thorw error if:
-      // - The user connects it to a node that is not from the quantum library
-      // - The user does not input a qubit object in the node
-      // - the user chooses to use registers but does not initiate them
-      if (msg.topic !== 'Quantum Circuit') {
-        throw new Error(
-            'The Identity gate node must be connected to nodes from the quantum library only.',
-        );
-      } else if (
-        typeof msg.payload.register === 'undefined' &&
-        typeof msg.payload.qubit === 'undefined'
-      ) {
-        throw new Error(
-            'The Identity gate node must be receive qubits objects as inputs.\n' +
-            'Please use "Quantum Circut" and "Quantum Register" node to generate qubits objects.',
-        );
-      } else if (
-        typeof msg.payload.qubit === 'undefined'
-      ) {
-        throw new Error(
-            'If "Registers & Bits" was selected in the "Quantum Circuit" node, please make use of register nodes.',
-        );
-      }
+
+      // Validate the node input msg: check for qubit object.
+      // Throw corresponding errors if required.
+      errors.validateQubitInput(node, msg);
 
       if (typeof msg.payload.register === 'undefined') {
         script += util.format(snippets.IDENTITY, msg.payload.qubit);

--- a/quantum/nodes/identity-gate/identity-gate.js
+++ b/quantum/nodes/identity-gate/identity-gate.js
@@ -15,8 +15,13 @@ module.exports = function(RED) {
       let script = '';
 
       // Validate the node input msg: check for qubit object.
-      // Throw corresponding errors if required.
-      errors.validateQubitInput(node, msg);
+      // Return corresponding errors or null if no errors.
+      // Stop the node execution upon an error
+      let error = errors.validateQubitInput(msg);
+      if (error) {
+        done(error);
+        return;
+      }
 
       if (typeof msg.payload.register === 'undefined') {
         script += util.format(snippets.IDENTITY, msg.payload.qubit);
@@ -27,8 +32,11 @@ module.exports = function(RED) {
       // Run the script in the python shell, and if no error occurs
       // then send msg object to the next node
       await shell.execute(script, (err) => {
-        if (err) node.error(err);
-        else send(msg);
+        if (err) done(err);
+        else {
+          send(msg);
+          done();
+        }
       });
     });
   }

--- a/quantum/nodes/measure/measure.js
+++ b/quantum/nodes/measure/measure.js
@@ -5,12 +5,6 @@ const snippets = require('../../snippets');
 const shell = require('../../python').PythonShell;
 const errors = require('../../errors');
 
-const validateInput = (node, msg) => {
-  if (msg.topic !== 'Quantum Circuit') {
-    node.error(errors.NOT_QUANTUM_CIRCUIT, msg);
-  }
-};
-
 module.exports = function(RED) {
   function MeasureNode(config) {
     RED.nodes.createNode(this, config);
@@ -22,7 +16,11 @@ module.exports = function(RED) {
 
     this.on('input', async function(msg, send, done) {
       let script = '';
-      validateInput(node, msg);
+
+      // Validate the node input msg: check for qubit object.
+      // Throw corresponding errors if required.
+      errors.validateQubitInput(node, msg);
+
       const params = (!node.selectedRegVarName) ? `${msg.payload.qubit}, ${node.selectedBit}`:
         `${msg.payload.registerVar}[${msg.payload.qubit}], ` +
         `${node.selectedRegVarName}[${node.selectedBit}]`;

--- a/quantum/nodes/not-gate/not-gate.js
+++ b/quantum/nodes/not-gate/not-gate.js
@@ -3,6 +3,7 @@
 const util = require('util');
 const snippets = require('../../snippets');
 const shell = require('../../python').PythonShell;
+const errors = require('../../errors');
 
 module.exports = function(RED) {
   function NotGateNode(config) {
@@ -12,29 +13,10 @@ module.exports = function(RED) {
 
     this.on('input', async function(msg, send, done) {
       let script = '';
-      // Thorw error if:
-      // - The user connects it to a node that is not from the quantum library
-      // - The user does not input a qubit object in the node
-      // - the user chooses to use registers but does not initiate them
-      if (msg.topic !== 'Quantum Circuit') {
-        throw new Error(
-            'The Not Gate node must be connected to nodes from the quantum library only.',
-        );
-      } else if (
-        typeof msg.payload.register === 'undefined' &&
-        typeof msg.payload.qubit === 'undefined'
-      ) {
-        throw new Error(
-            'The Not Gate node must be receive qubits objects as inputs.\n' +
-            'Please use "Quantum Circut" and "Quantum Register" node to generate qubits objects.',
-        );
-      } else if (
-        typeof msg.payload.qubit === 'undefined'
-      ) {
-        throw new Error(
-            'If "Registers & Bits" was selected in the "Quantum Circuit" node, please make use of register nodes.',
-        );
-      }
+
+      // Validate the node input msg: check for qubit object.
+      // Throw corresponding errors if required.
+      errors.validateQubitInput(node, msg);
 
       if (typeof msg.payload.register === 'undefined') {
         script += util.format(snippets.NOT_GATE, msg.payload.qubit);

--- a/quantum/nodes/not-gate/not-gate.js
+++ b/quantum/nodes/not-gate/not-gate.js
@@ -15,8 +15,13 @@ module.exports = function(RED) {
       let script = '';
 
       // Validate the node input msg: check for qubit object.
-      // Throw corresponding errors if required.
-      errors.validateQubitInput(node, msg);
+      // Return corresponding errors or null if no errors.
+      // Stop the node execution upon an error
+      let error = errors.validateQubitInput(msg);
+      if (error) {
+        done(error);
+        return;
+      }
 
       if (typeof msg.payload.register === 'undefined') {
         script += util.format(snippets.NOT_GATE, msg.payload.qubit);
@@ -27,8 +32,11 @@ module.exports = function(RED) {
       // Run the script in the python shell, and if no error occurs
       // then send msg object to the next node
       await shell.execute(script, (err) => {
-        if (err) node.error(err);
-        else send(msg);
+        if (err) done(err);
+        else {
+          send(msg);
+          done();
+        }
       });
     });
   }

--- a/quantum/nodes/phase-gate/phase-gate.js
+++ b/quantum/nodes/phase-gate/phase-gate.js
@@ -3,6 +3,7 @@
 const util = require('util');
 const snippets = require('../../snippets');
 const shell = require('../../python').PythonShell;
+const errors = require('../../errors');
 
 module.exports = function(RED) {
   function PhaseGateNode(config) {
@@ -13,29 +14,10 @@ module.exports = function(RED) {
 
     this.on('input', async function(msg, send, done) {
       let script = '';
-      // Thorw error if:
-      // - The user connects it to a node that is not from the quantum library
-      // - The user does not input a qubit object in the node
-      // - the user chooses to use registers but does not initiate them
-      if (msg.topic !== 'Quantum Circuit') {
-        throw new Error(
-            'The Phase gate node must be connected to nodes from the quantum library only.',
-        );
-      } else if (
-        typeof msg.payload.register === 'undefined' &&
-        typeof msg.payload.qubit === 'undefined'
-      ) {
-        throw new Error(
-            'The Phase gate node must be receive qubits objects as inputs.\n' +
-            'Please use "Quantum Circut" and "Quantum Register" node to generate qubits objects.',
-        );
-      } else if (
-        typeof msg.payload.qubit === 'undefined'
-      ) {
-        throw new Error(
-            'If "Registers & Bits" was selected in the "Quantum Circuit" node, please make use of register nodes.',
-        );
-      }
+
+      // Validate the node input msg: check for qubit object.
+      // Throw corresponding errors if required.
+      errors.validateQubitInput(node, msg);
 
       if (typeof msg.payload.register === 'undefined') {
         script += util.format(snippets.PHASE_GATE, node.phase + '*pi', msg.payload.qubit);

--- a/quantum/nodes/phase-gate/phase-gate.js
+++ b/quantum/nodes/phase-gate/phase-gate.js
@@ -16,8 +16,13 @@ module.exports = function(RED) {
       let script = '';
 
       // Validate the node input msg: check for qubit object.
-      // Throw corresponding errors if required.
-      errors.validateQubitInput(node, msg);
+      // Return corresponding errors or null if no errors.
+      // Stop the node execution upon an error
+      let error = errors.validateQubitInput(msg);
+      if (error) {
+        done(error);
+        return;
+      }
 
       if (typeof msg.payload.register === 'undefined') {
         script += util.format(snippets.PHASE_GATE, node.phase + '*pi', msg.payload.qubit);
@@ -31,15 +36,15 @@ module.exports = function(RED) {
       // Run the script in the python shell, and if no error occurs
       // then send msg object to the next node
       await shell.execute(script, (err) => {
-        if (err) node.error(err);
+        if (err) done(err);
         else {
           send(msg);
-
           node.status({
             fill: 'grey',
             shape: 'dot',
             text: 'Phase: \xa0' + node.phase.toString() + '\u03C0',
           });
+          done();
         };
       });
     });

--- a/quantum/nodes/quantum-circuit/quantum-circuit.js
+++ b/quantum/nodes/quantum-circuit/quantum-circuit.js
@@ -7,6 +7,7 @@ const shell = require('../../python').PythonShell;
 module.exports = function(RED) {
   let quantumCircuitNode = {};
   let classicalRegisters = [];
+
   function QuantumCircuitNode(config) {
     // Creating node with properties and context
     RED.nodes.createNode(this, config);
@@ -36,6 +37,7 @@ module.exports = function(RED) {
             topic: 'Quantum Circuit',
             payload: {
               structure: {
+                quantumCircuitId: node.id,
                 creg: node.cbitsreg,
                 qreg: node.qbitsreg,
               },
@@ -54,6 +56,7 @@ module.exports = function(RED) {
             topic: 'Quantum Circuit',
             payload: {
               structure: {
+                quantumCircuitId: node.id,
                 qubits: node.qbitsreg,
                 cbits: node.cbitsreg,
               },

--- a/quantum/nodes/quantum-circuit/quantum-circuit.js
+++ b/quantum/nodes/quantum-circuit/quantum-circuit.js
@@ -70,8 +70,11 @@ module.exports = function(RED) {
       // Sending one register object per node output
       await shell.restart();
       await shell.execute(script, (err) => {
-        if (err) node.error(err);
-        else send(output);
+        if (err) done(err);
+        else {
+          send(output);
+          done();
+        }
       });
     });
   }

--- a/quantum/nodes/quantum-register/quantum-register.js
+++ b/quantum/nodes/quantum-register/quantum-register.js
@@ -3,6 +3,7 @@
 const util = require('util');
 const snippets = require('../../snippets');
 const shell = require('../../python').PythonShell;
+const errors = require('../../errors');
 
 module.exports = function(RED) {
   function QuantumRegisterNode(config) {
@@ -16,23 +17,10 @@ module.exports = function(RED) {
 
     this.on('input', async function(msg, send, done) {
       let script = '';
-      // Throw a connection error if:
-      // - The user connects it to a node that is not from the quantum library
-      // - The user did not select the 'Registers & Bits' option in the 'Quantum Circuit' node
-      // - The user does not connect the register node to the output of the 'Quantum Circuit' node
-      if (msg.topic !== 'Quantum Circuit') {
-        throw new Error(
-            'Register nodes must be connected to nodes from the quantum library only',
-        );
-      } else if (typeof(msg.payload.register) === 'undefined') {
-        throw new Error(
-            'Select "Registers & Qubits" in the "Quantum Circuit" node properties to use registers.',
-        );
-      } else if (typeof(msg.payload.register) !== 'number') {
-        throw new Error(
-            'Register nodes must be connected to the outputs of the "Quantum Circuit" node.',
-        );
-      }
+
+      // Validate the node input msg: check for register object.
+      // Throw corresponding errors if required.
+      errors.validateRegisterInput(node, msg);
 
       // Setting node.name to "r0","r1"... if the user did not input a name
       if (node.name == '') {

--- a/quantum/nodes/quantum-register/quantum-register.js
+++ b/quantum/nodes/quantum-register/quantum-register.js
@@ -60,9 +60,7 @@ module.exports = function(RED) {
         // If the user specified a register structure in the 'Quantum Circuit' node that
         // does not match the visual structure built using the register nodes, throw an error
         if (qreg > msg.payload.structure.qreg || creg > msg.payload.structure.creg) {
-          throw new Error(
-              'Please enter the correct number of quantum & classical registers in the "Quantum Circuit" node.',
-          );
+          node.error(errors.INVALID_REGISTER_NUMBER);
 
         // If all set & the quantum circuit has not yet been initialised by another register:
         // Initialise the quantum circuit

--- a/quantum/nodes/qubit/qubit.js
+++ b/quantum/nodes/qubit/qubit.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const errors = require('../../errors');
+
 module.exports = function(RED) {
   function QubitNode(config) {
     // Creating node with properties
@@ -8,24 +10,9 @@ module.exports = function(RED) {
     const node = this;
 
     this.on('input', function(msg, send, done) {
-      // Throw a connection error if:
-      // - The user connects it to a node that is not from the quantum library
-      // - The user does not input a qubit object in the node
-      // - The user chooses to use registers but does not initiate them
-      if (msg.topic !== 'Quantum Circuit') {
-        throw new Error(
-            'Qubit nodes must be connected to nodes from the quantum library only.',
-        );
-      } else if (typeof(msg.payload.register) === 'undefined' && typeof(msg.payload.qubit) === 'undefined') {
-        throw new Error(
-            'Qubit nodes must receive qubits objects as inputs.\n' +
-            'Please use "Quantum Circuit" & "Quantum Register" nodes to generate qubits objects.',
-        );
-      } else if (typeof(msg.payload.qubit) === 'undefined') {
-        throw new Error(
-            'If "Registers & Bits" was selected in the "Quantum Circuit" node, please make use of register nodes.',
-        );
-      }
+      // Validate the node input msg: check for qubit object.
+      // Throw corresponding errors if required.
+      errors.validateQubitInput(node, msg);
 
       // Using node status to inform the user of which qubit is being transmitted
       if (typeof(msg.payload.register) === 'undefined') {

--- a/quantum/nodes/qubit/qubit.js
+++ b/quantum/nodes/qubit/qubit.js
@@ -11,8 +11,13 @@ module.exports = function(RED) {
 
     this.on('input', function(msg, send, done) {
       // Validate the node input msg: check for qubit object.
-      // Throw corresponding errors if required.
-      errors.validateQubitInput(node, msg);
+      // Return corresponding errors or null if no errors.
+      // Stop the node execution upon an error
+      let error = errors.validateQubitInput(msg);
+      if (error) {
+        done(error);
+        return;
+      }
 
       // Using node status to inform the user of which qubit is being transmitted
       if (typeof(msg.payload.register) === 'undefined') {
@@ -31,6 +36,7 @@ module.exports = function(RED) {
 
       // Simply return the msg received without any operations
       send(msg);
+      done();
     });
   }
 

--- a/quantum/nodes/reset/reset.js
+++ b/quantum/nodes/reset/reset.js
@@ -3,6 +3,7 @@
 const util = require('util');
 const snippets = require('../../snippets');
 const shell = require('../../python').PythonShell;
+const errors = require('../../errors');
 
 module.exports = function(RED) {
   function ResetNode(config) {
@@ -12,29 +13,10 @@ module.exports = function(RED) {
 
     this.on('input', async function(msg, send, done) {
       let script = '';
-      // Thorw error if:
-      // - The user connects it to a node that is not from the quantum library
-      // - The user does not input a qubit object in the node
-      // - the user chooses to use registers but does not initiate them
-      if (msg.topic !== 'Quantum Circuit') {
-        throw new Error(
-            'The Reset gate node must be connected to nodes from the quantum library only.',
-        );
-      } else if (
-        typeof msg.payload.register === 'undefined' &&
-        typeof msg.payload.qubit === 'undefined'
-      ) {
-        throw new Error(
-            'The Reset gate node must be receive qubits objects as inputs.\n' +
-            'Please use "Quantum Circut" and "Quantum Register" node to generate qubits objects.',
-        );
-      } else if (
-        typeof msg.payload.qubit === 'undefined'
-      ) {
-        throw new Error(
-            'If "Registers & Bits" was selected in the "Quantum Circuit" node, please make use of register nodes.',
-        );
-      }
+
+      // Validate the node input msg: check for qubit object.
+      // Throw corresponding errors if required.
+      errors.validateQubitInput(node, msg);
 
       if (typeof msg.payload.register === 'undefined') {
         script += util.format(snippets.RESET, msg.payload.qubit);

--- a/quantum/nodes/reset/reset.js
+++ b/quantum/nodes/reset/reset.js
@@ -15,8 +15,13 @@ module.exports = function(RED) {
       let script = '';
 
       // Validate the node input msg: check for qubit object.
-      // Throw corresponding errors if required.
-      errors.validateQubitInput(node, msg);
+      // Return corresponding errors or null if no errors.
+      // Stop the node execution upon an error
+      let error = errors.validateQubitInput(msg);
+      if (error) {
+        done(error);
+        return;
+      }
 
       if (typeof msg.payload.register === 'undefined') {
         script += util.format(snippets.RESET, msg.payload.qubit);
@@ -27,8 +32,11 @@ module.exports = function(RED) {
       // Run the script in the python shell, and if no error occurs
       // then send msg object to the next node
       await shell.execute(script, (err) => {
-        if (err) node.error(err);
-        else send(msg);
+        if (err) done(err);
+        else {
+          send(msg);
+          done();
+        }
       });
     });
   }

--- a/quantum/nodes/rotation-gate/rotation-gate.js
+++ b/quantum/nodes/rotation-gate/rotation-gate.js
@@ -17,8 +17,13 @@ module.exports = function(RED) {
       let script = '';
 
       // Validate the node input msg: check for qubit object.
-      // Throw corresponding errors if required.
-      errors.validateQubitInput(node, msg);
+      // Return corresponding errors or null if no errors.
+      // Stop the node execution upon an error
+      let error = errors.validateQubitInput(msg);
+      if (error) {
+        done(error);
+        return;
+      }
 
       if (typeof msg.payload.register === 'undefined') {
         script += util.format(snippets.ROTATION_GATE,
@@ -37,15 +42,15 @@ module.exports = function(RED) {
       // Run the script in the python shell, and if no error occurs
       // then send msg object to the next node
       await shell.execute(script, (err) => {
-        if (err) node.error(err);
+        if (err) done(err);
         else {
           send(msg);
-
           node.status({
             fill: 'grey',
             shape: 'dot',
             text: node.axis.toUpperCase() + ' axis: \xa0' + node.angle.toString() + '\u03C0',
           });
+          done();
         };
       });
     });

--- a/quantum/nodes/rotation-gate/rotation-gate.js
+++ b/quantum/nodes/rotation-gate/rotation-gate.js
@@ -3,6 +3,7 @@
 const util = require('util');
 const snippets = require('../../snippets');
 const shell = require('../../python').PythonShell;
+const errors = require('../../errors');
 
 module.exports = function(RED) {
   function RotationGateNode(config) {
@@ -14,29 +15,10 @@ module.exports = function(RED) {
 
     this.on('input', async function(msg, send, done) {
       let script = '';
-      // Thorw error if:
-      // - The user connects it to a node that is not from the quantum library
-      // - The user does not input a qubit object in the node
-      // - the user chooses to use registers but does not initiate them
-      if (msg.topic !== 'Quantum Circuit') {
-        throw new Error(
-            'The Rotation gate node must be connected to nodes from the quantum library only.',
-        );
-      } else if (
-        typeof msg.payload.register === 'undefined' &&
-        typeof msg.payload.qubit === 'undefined'
-      ) {
-        throw new Error(
-            'The Rotation gate node must be receive qubits objects as inputs.\n' +
-            'Please use "Quantum Circut" and "Quantum Register" node to generate qubits objects.',
-        );
-      } else if (
-        typeof msg.payload.qubit === 'undefined'
-      ) {
-        throw new Error(
-            'If "Registers & Bits" was selected in the "Quantum Circuit" node, please make use of register nodes.',
-        );
-      }
+
+      // Validate the node input msg: check for qubit object.
+      // Throw corresponding errors if required.
+      errors.validateQubitInput(node, msg);
 
       if (typeof msg.payload.register === 'undefined') {
         script += util.format(snippets.ROTATION_GATE,

--- a/quantum/nodes/simulator/simulator.js
+++ b/quantum/nodes/simulator/simulator.js
@@ -26,49 +26,53 @@ module.exports = function(RED) {
         node.qreg = undefined;
         node.qubits.push(msg);
 
-        // If the simulator node has more inputs than qubits in the circuit
-        if (node.qubits.length > msg.payload.structure.qubits) {
-          throw new Error(
-              'Only qubits from a single quantum circuit should be connected to the simulator node.',
-          );
         // If not all qubits have arrived
-        } else if (node.qubits.length < msg.payload.structure.qubits) qubitsArrived = false;
-      } else {// If the quantum circuit has registers
+        if (node.qubits.length < msg.payload.structure.qubits) {
+          qubitsArrived = false;
+        }
+      } else {
+        // If the quantum circuit has registers
         // Keep track of qubits that have arrived and the remaining ones
         if (node.qubits.length == 0) node.qreg = {};
-        else if (Object.keys(node.qreg).includes(msg.payload.registerVar)) {
+
+        // Throw an error if too many qubits are received by the simulator node
+        // because the user connected qubits from different quantum circuits
+        if ((
+          !Object.keys(node.qreg).includes(msg.payload.registerVar) &&
+          Object.keys(node.qreg).length == msg.payload.structure.qreg
+        ) || (
+          Object.keys(node.qreg).includes(msg.payload.registerVar) &&
+          node.qreg[msg.payload.registerVar].count == node.qreg[msg.payload.registerVar].total
+        )) {
+          node.error(errors.QUBITS_FROM_DIFFERENT_CIRCUITS);
+        }
+
+        // Storing information about which qubits were received
+        if (Object.keys(node.qreg).includes(msg.payload.registerVar)) {
           node.qreg[msg.payload.registerVar].count += 1;
-        } else {
+        } else if (!Object.keys(node.qreg).includes(msg.payload.registerVar)) {
           node.qreg[msg.payload.registerVar] = {
             total: msg.payload.totalQubits,
             count: 1,
           };
         }
+
         node.qubits.push(msg);
 
-        // If the simulator node has inputs from more q-registers than there are in the circuit
-        if (Object.keys(node.qreg).length > msg.payload.structure.qreg) {
-          throw new Error(
-              // eslint-disable-next-line max-len
-              'Only qubits of quantum registers from the same quantum circuit should be connected to the simulator node.',
-          );
-        } else {
-          Object.keys(node.qreg).map((key) => {
-            // If the simulator node has inputs from more qubits than there are in a register
-            if (node.qreg[key].count > node.qreg[key].total) {
-              throw new Error(
-                  'Only qubits from a single quantum circuit should be connected to the simulator node.',
-              );
-              // If not all qubits have arrived
-            } else if (node.qreg[key].count < node.qreg[key].total) {
-              qubitsArrived = false;
-            }
-          });
-        }
+        // Checking whether all qubits have arrived or not
+        Object.keys(node.qreg).map((key) => {
+          if (node.qreg[key].count < node.qreg[key].total) {
+            qubitsArrived = false;
+          }
+        });
       }
 
-      // If all qubits have arrives, generate the simulator script and run it
+      // If all qubits have arrived,
+      // generate the simulator script and run it
       if (qubitsArrived) {
+        // Checking that all qubits received as input are from the same quantum circuit
+        errors.validateQubitsFromSameCircuit(node, node.qubits);
+
         // Emptying the runtime variables upon output
         node.qubits = [];
         node.qreg = '';
@@ -76,7 +80,9 @@ module.exports = function(RED) {
         const params = node.shots;
         script += util.format(snippets.SIMULATOR, params);
         await shell.execute(script, (err, data) => {
+          // Temporary
           node.error(shell.script);
+          //
           if (err) {
             node.error(err);
           } else {

--- a/quantum/nodes/simulator/simulator.js
+++ b/quantum/nodes/simulator/simulator.js
@@ -50,7 +50,7 @@ module.exports = function(RED) {
         // Storing information about which qubits were received
         if (Object.keys(node.qreg).includes(msg.payload.registerVar)) {
           node.qreg[msg.payload.registerVar].count += 1;
-        } else if (!Object.keys(node.qreg).includes(msg.payload.registerVar)) {
+        } else {
           node.qreg[msg.payload.registerVar] = {
             total: msg.payload.totalQubits,
             count: 1,

--- a/quantum/nodes/simulator/simulator.js
+++ b/quantum/nodes/simulator/simulator.js
@@ -5,12 +5,6 @@ const snippets = require('../../snippets');
 const shell = require('../../python').PythonShell;
 const errors = require('../../errors');
 
-const validateInput = (node, msg) => {
-  if (msg.topic !== 'Quantum Circuit') {
-    node.error(errors.NOT_QUANTUM_CIRCUIT, msg);
-  }
-};
-
 module.exports = function(RED) {
   function SimulatorNode(config) {
     RED.nodes.createNode(this, config);
@@ -21,8 +15,11 @@ module.exports = function(RED) {
 
     this.on('input', async function(msg, send, done) {
       let script = '';
-      validateInput(node, msg);
       let qubitsArrived = true;
+
+      // Validate the node input msg: check for qubit object.
+      // Throw corresponding errors if required.
+      errors.validateQubitInput(node, msg);
 
       // If the quantum circuit does not have registers
       if (typeof(msg.payload.register) === 'undefined') {

--- a/quantum/nodes/swap/swap.js
+++ b/quantum/nodes/swap/swap.js
@@ -23,6 +23,9 @@ module.exports = function(RED) {
 
       // If all qubits have arrived, we first reorder the node.qubits array for output consistency
       if (node.qubits.length == 2) {
+        // Checking that all qubits received as input are from the same quantum circuit
+        errors.validateQubitsFromSameCircuit(node, node.qubits);
+
         node.qubits.sort(function compare(a, b) {
           if (typeof a.payload.register !== 'undefined') {
             const regA = parseInt(a.payload.registerVar.slice(2));

--- a/quantum/nodes/swap/swap.js
+++ b/quantum/nodes/swap/swap.js
@@ -2,6 +2,7 @@
 const util = require('util');
 const snippets = require('../../snippets');
 const shell = require('../../python').PythonShell;
+const errors = require('../../errors');
 
 module.exports = function(RED) {
   function SwapNode(config) {
@@ -12,27 +13,10 @@ module.exports = function(RED) {
 
     this.on('input', async function(msg, send, done) {
       let script = '';
-      // Throw a connection error if:
-      // - The user connects it to a node that is not from the quantum library.
-      // - The user does not input a qubit object in the node.
-      // - The user chooses to use registers but does not initiate them.
-      if (msg.topic !== 'Quantum Circuit') {
-        throw new Error(
-            'The SWAP node must be connected to nodes from the quantum library only.',
-        );
-      } else if (
-        typeof msg.payload.register === 'undefined' &&
-        typeof msg.payload.qubit === 'undefined'
-      ) {
-        throw new Error(
-            'The SWAP node must receive qubits objects as inputs.\n' +
-            'Please use "Quantum Circuit" & "Quantum Register" nodes to generate qubits objects.',
-        );
-      } else if (typeof msg.payload.qubit === 'undefined') {
-        throw new Error(
-            'If "Registers & Bits" was selected in the "Quantum Circuit" node, please make use of register nodes.',
-        );
-      }
+
+      // Validate the node input msg: check for qubit object.
+      // Throw corresponding errors if required.
+      errors.validateQubitInput(node, msg);
 
       // Store all the qubit objects received as input into the node.qubits array
       node.qubits.push(msg);

--- a/quantum/nodes/swap/swap.js
+++ b/quantum/nodes/swap/swap.js
@@ -15,8 +15,13 @@ module.exports = function(RED) {
       let script = '';
 
       // Validate the node input msg: check for qubit object.
-      // Throw corresponding errors if required.
-      errors.validateQubitInput(node, msg);
+      // Return corresponding errors or null if no errors.
+      // Stop the node execution upon an error
+      let error = errors.validateQubitInput(msg);
+      if (error) {
+        done(error);
+        return;
+      }
 
       // Store all the qubit objects received as input into the node.qubits array
       node.qubits.push(msg);
@@ -24,7 +29,11 @@ module.exports = function(RED) {
       // If all qubits have arrived, we first reorder the node.qubits array for output consistency
       if (node.qubits.length == 2) {
         // Checking that all qubits received as input are from the same quantum circuit
-        errors.validateQubitsFromSameCircuit(node, node.qubits);
+        let error = errors.validateQubitsFromSameCircuit(node.qubits);
+        if (error) {
+          done(error);
+          return;
+        }
 
         node.qubits.sort(function compare(a, b) {
           if (typeof a.payload.register !== 'undefined') {
@@ -61,12 +70,11 @@ module.exports = function(RED) {
         // Run the script in the python shell, and if no error occurs
         // then send one qubit object per node output
         await shell.execute(script, (err) => {
-          if (err) node.error(err);
+          if (err) done(err);
           else {
             send(node.qubits);
-
-            // Emptying the runtime variable upon output
-            node.qubits = [];
+            node.qubits = []; // Emptying the runtime variable upon output
+            done();
           }
         });
       }

--- a/quantum/nodes/toffoli-gate/toffoli-gate.js
+++ b/quantum/nodes/toffoli-gate/toffoli-gate.js
@@ -24,6 +24,9 @@ module.exports = function(RED) {
 
       // If all qubits have arrived, we first reorder the node.qubits array for output consistency
       if (node.qubits.length == 3) {
+        // Checking that all qubits received as input are from the same quantum circuit
+        errors.validateQubitsFromSameCircuit(node, node.qubits);
+
         node.qubits.sort(function compare(a, b) {
           if (typeof a.payload.register !== 'undefined') {
             const regA = parseInt(a.payload.registerVar.slice(2));

--- a/quantum/nodes/toffoli-gate/toffoli-gate.js
+++ b/quantum/nodes/toffoli-gate/toffoli-gate.js
@@ -2,6 +2,7 @@
 const util = require('util');
 const snippets = require('../../snippets');
 const shell = require('../../python').PythonShell;
+const errors = require('../../errors');
 
 module.exports = function(RED) {
   function ToffoliGateNode(config) {
@@ -13,27 +14,10 @@ module.exports = function(RED) {
 
     this.on('input', async function(msg, send, done) {
       let script = '';
-      // Throw a connection error if:
-      // - The user connects it to a node that is not from the quantum library.
-      // - The user does not input a qubit object in the node.
-      // - The user chooses to use registers but does not initiate them.
-      if (msg.topic !== 'Quantum Circuit') {
-        throw new Error(
-            'The Toffoli Gate must be connected to nodes from the quantum library only.',
-        );
-      } else if (
-        typeof msg.payload.register === 'undefined' &&
-        typeof msg.payload.qubit === 'undefined'
-      ) {
-        throw new Error(
-            'The Toffoli Gate nodes must receive qubits objects as inputs.\n' +
-            'Please use "Quantum Circuit" & "Quantum Register" nodes to generate qubits objects.',
-        );
-      } else if (typeof msg.payload.qubit === 'undefined') {
-        throw new Error(
-            'If "Registers & Bits" was selected in the "Quantum Circuit" node, please make use of register nodes.',
-        );
-      }
+
+      // Validate the node input msg: check for qubit object.
+      // Throw corresponding errors if required.
+      errors.validateQubitInput(node, msg);
 
       // Store all the qubit objects received as input into the node.qubits array
       node.qubits.push(msg);

--- a/quantum/nodes/toffoli-gate/toffoli-gate.js
+++ b/quantum/nodes/toffoli-gate/toffoli-gate.js
@@ -16,8 +16,13 @@ module.exports = function(RED) {
       let script = '';
 
       // Validate the node input msg: check for qubit object.
-      // Throw corresponding errors if required.
-      errors.validateQubitInput(node, msg);
+      // Return corresponding errors or null if no errors.
+      // Stop the node execution upon an error
+      let error = errors.validateQubitInput(msg);
+      if (error) {
+        done(error);
+        return;
+      }
 
       // Store all the qubit objects received as input into the node.qubits array
       node.qubits.push(msg);
@@ -25,7 +30,11 @@ module.exports = function(RED) {
       // If all qubits have arrived, we first reorder the node.qubits array for output consistency
       if (node.qubits.length == 3) {
         // Checking that all qubits received as input are from the same quantum circuit
-        errors.validateQubitsFromSameCircuit(node, node.qubits);
+        let error = errors.validateQubitsFromSameCircuit(node.qubits);
+        if (error) {
+          done(error);
+          return;
+        }
 
         node.qubits.sort(function compare(a, b) {
           if (typeof a.payload.register !== 'undefined') {
@@ -106,12 +115,11 @@ module.exports = function(RED) {
         // Run the script in the python shell, and if no error occurs
         // then send one qubit object per node output
         await shell.execute(script, (err) => {
-          if (err) node.error(err);
+          if (err) done(err);
           else {
             send(node.qubits);
-
-            // Emptying the runtime variable upon output
-            node.qubits = [];
+            node.qubits = []; // Emptying the runtime variable upon output
+            done();
           }
         });
       }

--- a/quantum/nodes/unitary-gate/unitary-gate.js
+++ b/quantum/nodes/unitary-gate/unitary-gate.js
@@ -3,6 +3,7 @@
 const util = require('util');
 const snippets = require('../../snippets');
 const shell = require('../../python').PythonShell;
+const errors = require('../../errors');
 
 module.exports = function(RED) {
   function UnitaryGateNode(config) {
@@ -15,29 +16,10 @@ module.exports = function(RED) {
 
     this.on('input', async function(msg, send, done) {
       let script = '';
-      // Thorw error if:
-      // - The user connects it to a node that is not from the quantum library
-      // - The user does not input a qubit object in the node
-      // - the user chooses to use registers but does not initiate them
-      if (msg.topic !== 'Quantum Circuit') {
-        throw new Error(
-            'The Unitary gate node must be connected to nodes from the quantum library only.',
-        );
-      } else if (
-        typeof msg.payload.register === 'undefined' &&
-        typeof msg.payload.qubit === 'undefined'
-      ) {
-        throw new Error(
-            'The Unitary gate node must be receive qubits objects as inputs.\n' +
-            'Please use "Quantum Circut" and "Quantum Register" node to generate qubits objects.',
-        );
-      } else if (
-        typeof msg.payload.qubit === 'undefined'
-      ) {
-        throw new Error(
-            'If "Registers & Bits" was selected in the "Quantum Circuit" node, please make use of register nodes.',
-        );
-      }
+
+      // Validate the node input msg: check for qubit object.
+      // Throw corresponding errors if required.
+      errors.validateQubitInput(node, msg);
 
       if (typeof msg.payload.register === 'undefined') {
         script += util.format(snippets.UNITARY_GATE,


### PR DESCRIPTION
### Purpose
Implementation of an `error.js` file that exports 3 functions:

- `validateQubitInput` checks that the node input `msg` is a qubit object
- `validateRegisterInput` checks that the node input `msg` is a register object
- `validateQubitsFromSameCircuit` checks that all qubits received (multiple qubit gates) are from the same QC.

If the node input is not validated, corresponding errors with explicit error messages are thrown.

### Changes

- `error.js` file
- Replaced the error handling code block at the beginning of each node by an import statement and a call to the appropriate input validation function.
- Added input validation for multiple qubit gates to check that all qubits are from the same quantum circuit.
- Replace all other error messages using `error.js` in the same way as in `snippet.js`
- Since I was editing `simulator.js`, I fixed issue #36 at the same time.

Closes #36 

### New Requirements

In `msg.payload.structure` there is now an element storing the 'Quantum Circuit' node ID in order to check whether 2 qubits are from the same quantum circuit or not.