### PR TITLE
Louis/circuit-button

### DIFF
--- a/quantum/nodes/quantum-circuit/quantum-circuit.html
+++ b/quantum/nodes/quantum-circuit/quantum-circuit.html
@@ -33,7 +33,7 @@
         value: "",
       },
     },
-    inputs: 1,
+    inputs: 0,
     icon: "font-awesome/fa-play-circle",
     align: "left",
     paletteLabel: "quantum circuit",
@@ -46,6 +46,28 @@
       } else {
         return "Register r" + index;
       }
+    },
+    button: {
+      enabled: function () {
+        return !this.changed;
+      },
+      onclick: function () {
+        if (this.changed) {
+          RED.notify(RED._("notification.warning", { message: RED._("notification.warnings.undeployedChanges") }), 
+          "warning");
+        } else {
+          $.ajax({
+            url: `quantum-circuit/${this.id}`,
+            type: "POST",
+            success: function (resp) {
+              RED.notify("Deploying quantum circuit", "success");
+            },
+            error: function (resp) {
+              RED.notify("Failed to deploy quantum circuit", "error");
+            },
+          });
+        }
+      },
     },
 
     oneditprepare: function () {

--- a/quantum/nodes/quantum-circuit/quantum-circuit.html
+++ b/quantum/nodes/quantum-circuit/quantum-circuit.html
@@ -33,7 +33,7 @@
         value: "",
       },
     },
-    inputs: 0,
+    inputs: 1,
     icon: "font-awesome/fa-play-circle",
     align: "left",
     paletteLabel: "quantum circuit",

--- a/quantum/nodes/quantum-circuit/quantum-circuit.js
+++ b/quantum/nodes/quantum-circuit/quantum-circuit.js
@@ -149,5 +149,16 @@ module.exports = function(RED) {
     });
   });
 
+  RED.httpAdmin.post('/quantum-circuit/:id', RED.auth.needsPermission('circuit.write'), function(req, res) {
+    let node = RED.nodes.getNode(req.params.id);
+
+    if (node == null) {
+      res.sendStatus(404);
+    } else {
+      node.receive();
+      res.sendStatus(200);
+    }
+  });
+
   RED.nodes.registerType('quantum-circuit', QuantumCircuitNode);
 };


### PR DESCRIPTION
### Purpose
<!-- Explain what this pull request is adding to the project. -->
Small addition to the quantum circuit node which adds a start button, same as the inject node. Given that we don't send any data to the quantum circuit via inject and its purpose is purely to start the circuit, figured it would make sense just to implement our own button. I think it also makes it clearer to the user that this is the starting point for the circuit. Also added custom success/error messages when the flow is deployed, as seen in the screenshot.

![button](https://user-images.githubusercontent.com/48141481/127565035-046486b4-0ae9-4dc6-879f-2f2748a74a7c.png)
