### PR TITLE
Hadamard gate typo fixed

### DIFF
--- a/quantum/nodes/hadamard-gate/hadamard-gate.js
+++ b/quantum/nodes/hadamard-gate/hadamard-gate.js
@@ -24,7 +24,7 @@ module.exports = function(RED) {
 
       let qrConfig = msg.payload;
       script += util.format(snippets.HADAMARD_GATE,
-        qrConfig.register ? `q${qrConfig.register}[${qrConfig.qubit}]` : `${qrConfig.qubit}`);
+        qrConfig.register ? `${qrConfig.registerVar}[${qrConfig.qubit}]` : `${qrConfig.qubit}`);
 
       // execute the script and pass the quantum register config to the output if no errors occurred
       await shell.execute(script, (err) => {


### PR DESCRIPTION
### Purpose
An error in `hadamard.js` was leading to multiple issues when using registers in the quantum circuit.


### Changes
The typo that was resulting in this bug is now fixed.
