### PR TITLE
Louis/flow-builder

### DIFF
--- a/quantum/python.js
+++ b/quantum/python.js
@@ -64,6 +64,7 @@ class PythonShell {
   constructor(path) {
     this.path = path ? path : pythonPath;
     this.script = '';
+    this.lastCommand = '';
   }
 
   /**
@@ -90,6 +91,7 @@ class PythonShell {
       }
 
       command = command ? command : '';
+      this.lastCommand = command;
       command = '\n' + command + '\n';
       this.script += command;
       command += '\nprint("#StdoutEnd#")\n';
@@ -142,6 +144,7 @@ class PythonShell {
       this.process.kill();
       this.process = null;
       this.script = '';
+      this.lastCommand = '';
     }
   }
 

--- a/test/flow-builder.js
+++ b/test/flow-builder.js
@@ -31,26 +31,51 @@ class FlowBuilder {
     this.nodes = [];
   }
 
+  /**
+   * Return the flow JSON as a string.
+   *
+   * This method is primarily intended for debugging purposes.
+   *
+   * @return {string} The JSON representation of the flow.
+  */
   get flowString() {
     return JSON.stringify(this.flow);
   }
 
-  add(type, id, wires, properties) {
-    if (!NODES.hasOwnProperty(type)) {
-      throw new Error(`Failed to find node ${type}`);
+  /**
+   * Add a quantum node to the flow.
+   *
+   * @param {string} name The name of the node.
+   * @param {string} id The id of the node.
+   * @param {string[]} wires The nodes which are connected to the output.
+   * @param {Object.<string, string>} properties The properties of the node (optional).
+  */
+  add(name, id, wires, properties) {
+    if (!NODES.hasOwnProperty(name)) {
+      throw new Error(`Failed to find node ${name}`);
     }
-    let name = type.replace(/-/g, ' ');
-    let json = {id: id, wires: [wires], type: type, name: name};
+    let json = {id: id, wires: [wires], type: name, name: name.replace(/-/g, ' ')};
     Object.assign(json, properties);
-    this.nodes.push(NODES[type]);
+    this.nodes.push(NODES[name]);
     this.flow.push(json);
   }
 
+  /**
+   * Add an output node to the flow.
+   *
+   * This is a node provided by the Node-RED Test Helper specifically for reading
+   * the output of the flow. This node should usually be the last node in the flow.
+   *
+   * @param {string} id The id of the node.
+  */
   addOutput(id) {
     let json = {id: id, type: 'helper', name: 'output'};
     this.flow.push(json);
   }
 
+  /**
+   * Reset the flow to be empty.
+  */
   reset() {
     this.flow = [];
     this.nodes = [];

--- a/test/flow-builder.js
+++ b/test/flow-builder.js
@@ -1,0 +1,186 @@
+'use strict';
+
+const barrierNode = require('../quantum/nodes/barrier/barrier.js');
+const blochSphereNode = require('../quantum/nodes/bloch-sphere/bloch-sphere.js');
+const circuitDiagramNode = require('../quantum/nodes/circuit-diagram/circuit-diagram.js');
+const classicalRegisterNode = require('../quantum/nodes/classical-register/classical-register.js');
+const cnotGateNode = require('../quantum/nodes/cnot-gate/cnot-gate.js');
+const controlledUGateNode = require('../quantum/nodes/controlled-u-gate/controlled-u-gate.js');
+const hadamardGateNode = require('../quantum/nodes/hadamard-gate/hadamard-gate.js');
+const ibmQuantumSystemNode = require('../quantum/nodes/ibm-quantum-system/ibm-quantum-system.js');
+const identityGateNode = require('../quantum/nodes/identity-gate/identity-gate.js');
+const localSimulatorNode = require('../quantum/nodes/local-simulator/local-simulator.js');
+const measureNode = require('../quantum/nodes/measure/measure.js');
+const notGateNode = require('../quantum/nodes/not-gate/not-gate.js');
+const phaseGateNode = require('../quantum/nodes/phase-gate/phase-gate.js');
+const quantumCircuitNode = require('../quantum/nodes/quantum-circuit/quantum-circuit.js');
+const quantumRegisterNode = require('../quantum/nodes/quantum-register/quantum-register.js');
+const qubitNode = require('../quantum/nodes/qubit/qubit.js');
+const resetNode = require('../quantum/nodes/reset/reset.js');
+const rotationGateNode = require('../quantum/nodes/rotation-gate/rotation-gate.js');
+const scriptNode = require('../quantum/nodes/script/script.js');
+const swapNode = require('../quantum/nodes/swap/swap.js');
+const toffoliGateNode = require('../quantum/nodes/toffoli-gate/toffoli-gate.js');
+const unitaryGateNode = require('../quantum/nodes/unitary-gate/unitary-gate.js');
+
+
+class FlowBuilder {
+  constructor() {
+    this.flow = [];
+    this.nodes = [];
+  }
+
+  get flowString() {
+    return JSON.stringify(this.flow);
+  }
+
+  reset() {
+    this.flow = [];
+    this.nodes = [];
+  }
+
+  add(node, json) {
+    this.nodes.push(node);
+    this.flow.push(json);
+  }
+
+  addHelper(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'helper', name: 'Helper Node'};
+    Object.assign(json, properties);
+    this.flow.push(json);
+  }
+
+  addBarrier(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'barrier', name: 'Barrier Node'};
+    Object.assign(json, properties);
+    this.add(barrierNode, json);
+  }
+
+  addBlochSphere(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'bloch-sphere', name: 'Bloch Sphere Node'};
+    Object.assign(json, properties);
+    this.add(blochSphereNode, json);
+  }
+
+  addCircuitDiagram(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'circuit-diagram', name: 'Circuit Diagram Node'};
+    Object.assign(json, properties);
+    this.add(circuitDiagramNode, json);
+  }
+
+  addClassicalRegister(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'classical-register', name: 'Classical Register Node'};
+    Object.assign(json, properties);
+    this.add(classicalRegisterNode, json);
+  }
+
+  addCnotGate(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'cnot-gate', name: 'CNot Gate Node'};
+    Object.assign(json, properties);
+    this.add(cnotGateNode, json);
+  }
+
+  addControlledUGate(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'controlled-u-gate', name: 'Controlled-U-Gate Node'};
+    Object.assign(json, properties);
+    this.add(controlledUGateNode, json);
+  }
+
+  addHadamardGate(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'hadamard-gate', name: 'Hadamard Gate Node'};
+    Object.assign(json, properties);
+    this.add(hadamardGateNode, json);
+  }
+
+  addIBMQuantumSystem(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'ibm-quantum-system', name: 'IBM Quantum System Node'};
+    Object.assign(json, properties);
+    this.add(ibmQuantumSystemNode, json);
+  }
+
+  addIdentityGate(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'identity-gate', name: 'Idenity Gate Node'};
+    Object.assign(json, properties);
+    this.add(identityGateNode, json);
+  }
+
+  addLocalSimulator(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'local-simulator', name: 'Local Simulator Node'};
+    Object.assign(json, properties);
+    this.add(localSimulatorNode, json);
+  }
+
+  addMeasure(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'measure', name: 'Measure Node'};
+    Object.assign(json, properties);
+    this.add(measureNode, json);
+  }
+
+  addNotGate(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'not-gate', name: 'Not Gate Node'};
+    Object.assign(json, properties);
+    this.add(notGateNode, json);
+  }
+
+  addPhaseGate(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'phase-gate', name: 'Phase Gate Node'};
+    Object.assign(json, properties);
+    this.add(phaseGateNode, json);
+  }
+
+  addQuantumCircuit(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'quantum-circuit', name: 'Quantum Circuit Node'};
+    Object.assign(json, properties);
+    this.add(quantumCircuitNode, json);
+  }
+
+  addQuantumRegister(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'quantum-register', name: 'Quantum Register Node'};
+    Object.assign(json, properties);
+    this.add(quantumRegisterNode, json);
+  }
+
+  addQubit(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'qubit', name: 'Qubit Node'};
+    Object.assign(json, properties);
+    this.add(qubitNode, json);
+  }
+
+  addReset(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'reset', name: 'Reset Node'};
+    Object.assign(json, properties);
+    this.add(resetNode, json);
+  }
+
+  addRotationGate(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'rotation-gate', name: 'Rotation Gate Node'};
+    Object.assign(json, properties);
+    this.add(rotationGateNode, json);
+  }
+
+  addScript(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'script', name: 'Script Node'};
+    Object.assign(json, properties);
+    this.add(scriptNode, json);
+  }
+
+  addSwap(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'swap', name: 'Swap Node'};
+    Object.assign(json, properties);
+    this.add(swapNode, json);
+  }
+
+  addToffoliGate(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'toffoli-gate', name: 'Toffoli Gate Node'};
+    Object.assign(json, properties);
+    this.add(toffoliGateNode, json);
+  }
+
+  addUnitaryGate(id, wires, properties) {
+    let json = {id: id, wires: [wires], type: 'unitary-gate', name: 'Unitary Gate Node'};
+    Object.assign(json, properties);
+    this.add(unitaryGateNode, json);
+  }
+}
+
+module.exports.FlowBuilder = FlowBuilder;

--- a/test/flow-builder.js
+++ b/test/flow-builder.js
@@ -1,28 +1,29 @@
 'use strict';
 
-const barrierNode = require('../quantum/nodes/barrier/barrier.js');
-const blochSphereNode = require('../quantum/nodes/bloch-sphere/bloch-sphere.js');
-const circuitDiagramNode = require('../quantum/nodes/circuit-diagram/circuit-diagram.js');
-const classicalRegisterNode = require('../quantum/nodes/classical-register/classical-register.js');
-const cnotGateNode = require('../quantum/nodes/cnot-gate/cnot-gate.js');
-const controlledUGateNode = require('../quantum/nodes/controlled-u-gate/controlled-u-gate.js');
-const hadamardGateNode = require('../quantum/nodes/hadamard-gate/hadamard-gate.js');
-const ibmQuantumSystemNode = require('../quantum/nodes/ibm-quantum-system/ibm-quantum-system.js');
-const identityGateNode = require('../quantum/nodes/identity-gate/identity-gate.js');
-const localSimulatorNode = require('../quantum/nodes/local-simulator/local-simulator.js');
-const measureNode = require('../quantum/nodes/measure/measure.js');
-const notGateNode = require('../quantum/nodes/not-gate/not-gate.js');
-const phaseGateNode = require('../quantum/nodes/phase-gate/phase-gate.js');
-const quantumCircuitNode = require('../quantum/nodes/quantum-circuit/quantum-circuit.js');
-const quantumRegisterNode = require('../quantum/nodes/quantum-register/quantum-register.js');
-const qubitNode = require('../quantum/nodes/qubit/qubit.js');
-const resetNode = require('../quantum/nodes/reset/reset.js');
-const rotationGateNode = require('../quantum/nodes/rotation-gate/rotation-gate.js');
-const scriptNode = require('../quantum/nodes/script/script.js');
-const swapNode = require('../quantum/nodes/swap/swap.js');
-const toffoliGateNode = require('../quantum/nodes/toffoli-gate/toffoli-gate.js');
-const unitaryGateNode = require('../quantum/nodes/unitary-gate/unitary-gate.js');
-
+const NODES = {
+  'barrier': require('../quantum/nodes/barrier/barrier.js'),
+  'bloch-sphere': require('../quantum/nodes/bloch-sphere/bloch-sphere.js'),
+  'circuit-diagram': require('../quantum/nodes/circuit-diagram/circuit-diagram.js'),
+  'classical-register': require('../quantum/nodes/classical-register/classical-register.js'),
+  'cnot-gate': require('../quantum/nodes/cnot-gate/cnot-gate.js'),
+  'controlled-u-gate': require('../quantum/nodes/controlled-u-gate/controlled-u-gate.js'),
+  'hadamard-gate': require('../quantum/nodes/hadamard-gate/hadamard-gate.js'),
+  'ibm-quantum-system': require('../quantum/nodes/ibm-quantum-system/ibm-quantum-system.js'),
+  'identity-gate': require('../quantum/nodes/identity-gate/identity-gate.js'),
+  'local-simulator': require('../quantum/nodes/local-simulator/local-simulator.js'),
+  'measure': require('../quantum/nodes/measure/measure.js'),
+  'not-gate': require('../quantum/nodes/not-gate/not-gate.js'),
+  'phase-gate': require('../quantum/nodes/phase-gate/phase-gate.js'),
+  'quantum-circuit': require('../quantum/nodes/quantum-circuit/quantum-circuit.js'),
+  'quantum-register': require('../quantum/nodes/quantum-register/quantum-register.js'),
+  'qubit': require('../quantum/nodes/qubit/qubit.js'),
+  'reset': require('../quantum/nodes/reset/reset.js'),
+  'rotation-gate': require('../quantum/nodes/rotation-gate/rotation-gate.js'),
+  'script': require('../quantum/nodes/script/script.js'),
+  'swap': require('../quantum/nodes/swap/swap.js'),
+  'toffoli-gate': require('../quantum/nodes/toffoli-gate/toffoli-gate.js'),
+  'unitary-gate': require('../quantum/nodes/unitary-gate/unitary-gate.js'),
+};
 
 class FlowBuilder {
   constructor() {
@@ -34,152 +35,25 @@ class FlowBuilder {
     return JSON.stringify(this.flow);
   }
 
+  add(type, id, wires, properties) {
+    if (!NODES.hasOwnProperty(type)) {
+      throw new Error(`Failed to find node ${type}`);
+    }
+    let name = type.replace(/-/g, ' ');
+    let json = {id: id, wires: [wires], type: type, name: name};
+    Object.assign(json, properties);
+    this.nodes.push(NODES[type]);
+    this.flow.push(json);
+  }
+
+  addOutput(id) {
+    let json = {id: id, type: 'helper', name: 'output'};
+    this.flow.push(json);
+  }
+
   reset() {
     this.flow = [];
     this.nodes = [];
-  }
-
-  add(node, json) {
-    this.nodes.push(node);
-    this.flow.push(json);
-  }
-
-  addHelper(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'helper', name: 'Helper Node'};
-    Object.assign(json, properties);
-    this.flow.push(json);
-  }
-
-  addBarrier(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'barrier', name: 'Barrier Node'};
-    Object.assign(json, properties);
-    this.add(barrierNode, json);
-  }
-
-  addBlochSphere(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'bloch-sphere', name: 'Bloch Sphere Node'};
-    Object.assign(json, properties);
-    this.add(blochSphereNode, json);
-  }
-
-  addCircuitDiagram(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'circuit-diagram', name: 'Circuit Diagram Node'};
-    Object.assign(json, properties);
-    this.add(circuitDiagramNode, json);
-  }
-
-  addClassicalRegister(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'classical-register', name: 'Classical Register Node'};
-    Object.assign(json, properties);
-    this.add(classicalRegisterNode, json);
-  }
-
-  addCnotGate(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'cnot-gate', name: 'CNot Gate Node'};
-    Object.assign(json, properties);
-    this.add(cnotGateNode, json);
-  }
-
-  addControlledUGate(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'controlled-u-gate', name: 'Controlled-U-Gate Node'};
-    Object.assign(json, properties);
-    this.add(controlledUGateNode, json);
-  }
-
-  addHadamardGate(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'hadamard-gate', name: 'Hadamard Gate Node'};
-    Object.assign(json, properties);
-    this.add(hadamardGateNode, json);
-  }
-
-  addIBMQuantumSystem(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'ibm-quantum-system', name: 'IBM Quantum System Node'};
-    Object.assign(json, properties);
-    this.add(ibmQuantumSystemNode, json);
-  }
-
-  addIdentityGate(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'identity-gate', name: 'Idenity Gate Node'};
-    Object.assign(json, properties);
-    this.add(identityGateNode, json);
-  }
-
-  addLocalSimulator(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'local-simulator', name: 'Local Simulator Node'};
-    Object.assign(json, properties);
-    this.add(localSimulatorNode, json);
-  }
-
-  addMeasure(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'measure', name: 'Measure Node'};
-    Object.assign(json, properties);
-    this.add(measureNode, json);
-  }
-
-  addNotGate(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'not-gate', name: 'Not Gate Node'};
-    Object.assign(json, properties);
-    this.add(notGateNode, json);
-  }
-
-  addPhaseGate(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'phase-gate', name: 'Phase Gate Node'};
-    Object.assign(json, properties);
-    this.add(phaseGateNode, json);
-  }
-
-  addQuantumCircuit(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'quantum-circuit', name: 'Quantum Circuit Node'};
-    Object.assign(json, properties);
-    this.add(quantumCircuitNode, json);
-  }
-
-  addQuantumRegister(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'quantum-register', name: 'Quantum Register Node'};
-    Object.assign(json, properties);
-    this.add(quantumRegisterNode, json);
-  }
-
-  addQubit(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'qubit', name: 'Qubit Node'};
-    Object.assign(json, properties);
-    this.add(qubitNode, json);
-  }
-
-  addReset(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'reset', name: 'Reset Node'};
-    Object.assign(json, properties);
-    this.add(resetNode, json);
-  }
-
-  addRotationGate(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'rotation-gate', name: 'Rotation Gate Node'};
-    Object.assign(json, properties);
-    this.add(rotationGateNode, json);
-  }
-
-  addScript(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'script', name: 'Script Node'};
-    Object.assign(json, properties);
-    this.add(scriptNode, json);
-  }
-
-  addSwap(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'swap', name: 'Swap Node'};
-    Object.assign(json, properties);
-    this.add(swapNode, json);
-  }
-
-  addToffoliGate(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'toffoli-gate', name: 'Toffoli Gate Node'};
-    Object.assign(json, properties);
-    this.add(toffoliGateNode, json);
-  }
-
-  addUnitaryGate(id, wires, properties) {
-    let json = {id: id, wires: [wires], type: 'unitary-gate', name: 'Unitary Gate Node'};
-    Object.assign(json, properties);
-    this.add(unitaryGateNode, json);
   }
 }
 

--- a/test/nodes/bloch-sphere_spec.js
+++ b/test/nodes/bloch-sphere_spec.js
@@ -1,0 +1,19 @@
+const blochSphereNode = require('../../quantum/nodes/bloch-sphere/bloch-sphere.js');
+const testUtil = require('../test-util');
+const nodeTestHelper = testUtil.nodeTestHelper;
+
+
+describe('BlochSphereNode', function() {
+  beforeEach(function(done) {
+    nodeTestHelper.startServer(done);
+  });
+
+  afterEach(function(done) {
+    nodeTestHelper.unload();
+    nodeTestHelper.stopServer(done);
+  });
+
+  it('load node', function(done) {
+    testUtil.isLoaded(blochSphereNode, 'bloch-sphere', done);
+  });
+});

--- a/test/nodes/circuit-diagram_spec.js
+++ b/test/nodes/circuit-diagram_spec.js
@@ -1,0 +1,19 @@
+const circuitDiagramNode = require('../../quantum/nodes/circuit-diagram/circuit-diagram.js');
+const testUtil = require('../test-util');
+const nodeTestHelper = testUtil.nodeTestHelper;
+
+
+describe('CircuitDiagramNode', function() {
+  beforeEach(function(done) {
+    nodeTestHelper.startServer(done);
+  });
+
+  afterEach(function(done) {
+    nodeTestHelper.unload();
+    nodeTestHelper.stopServer(done);
+  });
+
+  it('load node', function(done) {
+    testUtil.isLoaded(circuitDiagramNode, 'circuit-diagram', done);
+  });
+});

--- a/test/nodes/controlled-u-gate_spec.js
+++ b/test/nodes/controlled-u-gate_spec.js
@@ -1,0 +1,19 @@
+const controlledUGateNode = require('../../quantum/nodes/controlled-u-gate/controlled-u-gate.js');
+const testUtil = require('../test-util');
+const nodeTestHelper = testUtil.nodeTestHelper;
+
+
+describe('ControlledUGateNode', function() {
+  beforeEach(function(done) {
+    nodeTestHelper.startServer(done);
+  });
+
+  afterEach(function(done) {
+    nodeTestHelper.unload();
+    nodeTestHelper.stopServer(done);
+  });
+
+  it('load node', function(done) {
+    testUtil.isLoaded(controlledUGateNode, 'controlled-u-gate', done);
+  });
+});

--- a/test/nodes/local-simulator_spec.js
+++ b/test/nodes/local-simulator_spec.js
@@ -27,7 +27,7 @@ describe('LocalSimulatorNode', function() {
     flow.add('hadamard-gate', 'n1', ['n2']);
     flow.add('measure', 'n2', ['n3'], {selectedBit: '0'});
     flow.add('local-simulator', 'n3', ['n4'], {shots: '1'});
-    flow.addOutput('n4', []);
+    flow.addOutput('n4');
 
     nodeTestHelper.load(flow.nodes, flow.flow, function() {
       let n0 = nodeTestHelper.getNode('n0');

--- a/test/nodes/local-simulator_spec.js
+++ b/test/nodes/local-simulator_spec.js
@@ -1,6 +1,9 @@
 const localSimulatorNode = require('../../quantum/nodes/local-simulator/local-simulator.js');
 const testUtil = require('../test-util');
+const shell = require('../../quantum/python.js').PythonShell;
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const assert = require('chai').assert;
 
 
 describe('LocalSimulatorNode', function() {
@@ -9,11 +12,37 @@ describe('LocalSimulatorNode', function() {
   });
 
   afterEach(function(done) {
+    shell.stop();
     nodeTestHelper.unload();
     nodeTestHelper.stopServer(done);
   });
 
   it('load node', function(done) {
     testUtil.isLoaded(localSimulatorNode, 'local-simulator', done);
+  });
+
+  it('execute script', function(done) {
+    const flow = new FlowBuilder();
+    flow.addQuantumCircuit('n0', ['n1'], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.addHadamardGate('n1', ['n2']);
+    flow.addMeasure('n2', ['n3'], {selectedBit: '0'});
+    flow.addLocalSimulator('n3', ['n4'], {shots: '1'});
+    flow.addHelper('n4', []);
+
+    nodeTestHelper.load(flow.nodes, flow.flow, function() {
+      let n0 = nodeTestHelper.getNode('n0');
+      let n4 = nodeTestHelper.getNode('n4');
+
+      n4.on('input', function(msg) {
+        try {
+          assert.isNotEmpty(msg.payload);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+
+      n0.receive({payload: ''});
+    });
   });
 });

--- a/test/nodes/local-simulator_spec.js
+++ b/test/nodes/local-simulator_spec.js
@@ -1,9 +1,11 @@
-const localSimulatorNode = require('../../quantum/nodes/local-simulator/local-simulator.js');
+const util = require('util');
+const assert = require('chai').assert;
 const testUtil = require('../test-util');
-const shell = require('../../quantum/python.js').PythonShell;
 const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
-const assert = require('chai').assert;
+const localSimulatorNode = require('../../quantum/nodes/local-simulator/local-simulator.js');
+const shell = require('../../quantum/python.js').PythonShell;
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('LocalSimulatorNode', function() {
@@ -35,7 +37,8 @@ describe('LocalSimulatorNode', function() {
 
       n4.on('input', function(msg) {
         try {
-          assert.isNotEmpty(msg.payload);
+          let command = util.format(snippets.LOCAL_SIMULATOR, '1');
+          assert.strictEqual(shell.lastCommand, command);
           done();
         } catch (err) {
           done(err);

--- a/test/nodes/local-simulator_spec.js
+++ b/test/nodes/local-simulator_spec.js
@@ -23,11 +23,11 @@ describe('LocalSimulatorNode', function() {
 
   it('execute script', function(done) {
     const flow = new FlowBuilder();
-    flow.addQuantumCircuit('n0', ['n1'], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
-    flow.addHadamardGate('n1', ['n2']);
-    flow.addMeasure('n2', ['n3'], {selectedBit: '0'});
-    flow.addLocalSimulator('n3', ['n4'], {shots: '1'});
-    flow.addHelper('n4', []);
+    flow.add('quantum-circuit', 'n0', ['n1'], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('hadamard-gate', 'n1', ['n2']);
+    flow.add('measure', 'n2', ['n3'], {selectedBit: '0'});
+    flow.add('local-simulator', 'n3', ['n4'], {shots: '1'});
+    flow.addOutput('n4', []);
 
     nodeTestHelper.load(flow.nodes, flow.flow, function() {
       let n0 = nodeTestHelper.getNode('n0');

--- a/test/nodes/quantum-circuit_spec.js
+++ b/test/nodes/quantum-circuit_spec.js
@@ -13,7 +13,7 @@ describe('QuantumCircuitNode', function() {
     nodeTestHelper.stopServer(done);
   });
 
-  xit('load node', function(done) {
+  it('load node', function(done) {
     testUtil.isLoaded(quantumCircuitNode, 'quantum-circuit', done);
   });
 });

--- a/test/nodes/quantum-register_spec.js
+++ b/test/nodes/quantum-register_spec.js
@@ -13,7 +13,7 @@ describe('QuantumRegisterNode', function() {
     nodeTestHelper.stopServer(done);
   });
 
-  xit('load node', function(done) {
+  it('load node', function(done) {
     testUtil.isLoaded(quantumRegisterNode, 'quantum-register', done);
   });
 });

--- a/test/python_spec.js
+++ b/test/python_spec.js
@@ -15,7 +15,7 @@ describe('PythonShell', function() {
     });
 
     it('process starts empty', async function() {
-      assert.isUndefined(shell.process);
+      assert.isNull(shell.process);
     });
 
     it('script starts empty', async function() {


### PR DESCRIPTION
### Purpose
Adding the `FlowBuilder` class, which is intended to make the creation of flows for unit tests easier and more readable. Currently this only works with quantum nodes and not inbuilt ones, which I can add in the future.

I've added an explanation of the usage example in the comments of this PR.

***PR #82 needs to be merged before this PR, otherwise the additions here won't work due to `quantum-circuit.js` not loading***.

### Changes
- Add `lastCommand` property to PythonShell (beedc0e6ca9faee9b5965f6f80f15fb30c606817).
- Add load tests for nodes Bloch Sphere, Circuit Diagram, and Controlled-U-Gate (6116a50e81692a914c8566523b833f3f79cb7340).
- Add `FlowBuilder` (18c89ed2c37eceddfc9a2e4d5b324655c3e09c61 & 54212936b6f3713021ffe4ee49d605e5bbea9d55).
- Add example `FlowBuilder` usage (18c89ed2c37eceddfc9a2e4d5b324655c3e09c61 & 8b7cb726ae0702bf1ff4c02b2eb80c93b4b39cae).
- Re-enabled disabled Quantum Circuit and Quantum Register tests (3e94424ec03f695b01e69f3342f640bc3f42d780).
- Fix `PythonShell` test checking for undefined instead of null (00f61a09cfad53b7d9026fd84c530f61de100ccb).
