### PR TITLE
Khesim/ibm system update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "node-red-contrib-quantum",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/quantum/errors.js
+++ b/quantum/errors.js
@@ -44,10 +44,6 @@ const BLOCH_SPHERE_WITH_MEASUREMENT =
 'measuring a qubit can collapse its state and lead to inconsistencies.\n'+
 'Please disconnect or remove any "Measure" node from the quantum circuit.';
 
-const DEFAULT_SIMULATOR_TOO_SMALL =
-'The quantum circuit provided has too many qubits to be run on the default QASM Simulator. ' +
-'Please enter the name of a simulator with enough qubits to run this circuit.';
-
 function validateQubitInput(msg) {
   let keys = Object.keys(msg.payload);
 
@@ -120,7 +116,6 @@ module.exports = {
   QUBITS_FROM_DIFFERENT_CIRCUITS,
   SAME_QUBIT_RECEIVED_TWICE,
   BLOCH_SPHERE_WITH_MEASUREMENT,
-  DEFAULT_SIMULATOR_TOO_SMALL,
   validateQubitInput,
   validateRegisterInput,
   validateQubitsFromSameCircuit,

--- a/quantum/errors.js
+++ b/quantum/errors.js
@@ -44,6 +44,10 @@ const BLOCH_SPHERE_WITH_MEASUREMENT =
 'measuring a qubit can collapse its state and lead to inconsistencies.\n'+
 'Please disconnect or remove any "Measure" node from the quantum circuit.';
 
+const DEFAULT_SIMULATOR_TOO_SMALL =
+'The quantum circuit provided has too many qubits to be run on the default QASM Simulator. ' +
+'Please enter the name of a simulator with enough qubits to run this circuit.';
+
 function validateQubitInput(msg) {
   let keys = Object.keys(msg.payload);
 
@@ -116,6 +120,7 @@ module.exports = {
   QUBITS_FROM_DIFFERENT_CIRCUITS,
   SAME_QUBIT_RECEIVED_TWICE,
   BLOCH_SPHERE_WITH_MEASUREMENT,
+  DEFAULT_SIMULATOR_TOO_SMALL,
   validateQubitInput,
   validateRegisterInput,
   validateQubitsFromSameCircuit,

--- a/quantum/nodes/ibm-quantum-system/ibm-quantum-system.html
+++ b/quantum/nodes/ibm-quantum-system/ibm-quantum-system.html
@@ -55,7 +55,7 @@
   </div>
 
   <div class="form-row">
-    <label for="node-input-shots"><i class="fa fa-tag"></i> Shots</label>
+    <label for="node-input-shots">Shots</label>
     <input type="number" min="1" id="node-input-shots" placeholder="1000"/>
   </div>
 

--- a/quantum/nodes/ibm-quantum-system/ibm-quantum-system.html
+++ b/quantum/nodes/ibm-quantum-system/ibm-quantum-system.html
@@ -4,9 +4,10 @@
     color: "#A8A8A8",
     defaults: {
       name: { value: "" },
-      chosen_system: {value: ""},
       api_token: { value: "", required: true },
+      chosen_system: {value: ""},
       preferred_backend: { value: "" },
+      shots: { value: 0, validate: RED.validators.number() },
       preferred_output: { value: "" },
     },
     inputs: 1,
@@ -42,14 +43,6 @@
   </div>
 
   <div class="form-row">
-    <label for="node-input-preferred_output">Output Format</label>
-    <select name="preferred_output" id="node-input-preferred_output">
-      <option value="Results">Results Only</option>
-      <option value="Verbose">Verbose</option>
-    </select>
-  </div>
-
-  <div class="form-row">
     <label for="node-input-preferred_backend" id="user-backend"
       >Quantum Backend
     </label>
@@ -59,6 +52,19 @@
       placeholder="Preferred Backend"
       style="margin-bottom: 20px;"
     />
+  </div>
+
+  <div class="form-row">
+    <label for="node-input-shots"><i class="fa fa-tag"></i> Shots</label>
+    <input type="number" id="node-input-shots" placeholder="1000"/>
+  </div>
+
+  <div class="form-row">
+    <label for="node-input-preferred_output">Output Format</label>
+    <select name="preferred_output" id="node-input-preferred_output">
+      <option value="Results">Results Only</option>
+      <option value="Verbose">Verbose</option>
+    </select>
   </div>
 
 </script>

--- a/quantum/nodes/ibm-quantum-system/ibm-quantum-system.html
+++ b/quantum/nodes/ibm-quantum-system/ibm-quantum-system.html
@@ -7,7 +7,17 @@
       api_token: { value: "", required: true },
       chosen_system: { value: "" },
       preferred_backend: { value: "" },
-      shots: { value: 1, validate: RED.validators.number() },
+      shots: { 
+        value: 1, 
+        validate: function (x) {
+          x = parseInt(x);
+          if (Number.isInteger(x) && x > 0) {
+            return true;
+          } else {
+            return false;
+          }
+        },
+      },
       preferred_output: { value: "" },
     },
     inputs: 1,
@@ -34,23 +44,21 @@
     <input type="text" id="node-input-api_token" placeholder="API Token" style="margin-bottom: 20px;"/>
   </div>
 
-  <div class="form-row">
-    <label for="node-input-chosen_system">Simulator/Qubit System</label>
-    <select name="chosen_system" id="node-input-chosen_system">
+  <div style="width:40%; text-align:center; float:left; margin-bottom: 40px;">
+    <label for="node-input-chosen_system">Least Busy Backend</label>
+    <select name="chosen_system" id="node-input-chosen_system" style="width:85%">
       <option value="Simulator">Simulator</option>
-      <option value="Qubit_System">Qubit System</option>
+      <option value="Qubit_System">Quantum System</option>
     </select>
   </div>
-
-  <div class="form-row">
-    <label for="node-input-preferred_backend" id="user-backend"
-      >Quantum Backend
-    </label>
+  <div style="width:5%; font-size:10pt; text-align:center; float:left; margin-top: 20px;">OR</div>
+  <div style="width:40%; text-align:center; float:left; margin-bottom: 40px;">
+    <label for="node-input-preferred_backend" id="user-backend">Specific Backend</label>
     <input
       type="text"
       id="node-input-preferred_backend"
       placeholder="Preferred Backend"
-      style="margin-bottom: 20px;"
+      style="width:85%"
     />
   </div>
 

--- a/quantum/nodes/ibm-quantum-system/ibm-quantum-system.html
+++ b/quantum/nodes/ibm-quantum-system/ibm-quantum-system.html
@@ -4,6 +4,7 @@
     color: "#A8A8A8",
     defaults: {
       name: { value: "" },
+      chosen_system: {value: ""},
       api_token: { value: "", required: true },
       preferred_backend: { value: "" },
       preferred_output: { value: "" },
@@ -15,7 +16,7 @@
     label: function () {
       return this.name || "ibm quantum system";
     },
-  });
+  })
 </script>
 
 <script type="text/html" data-template-name="ibm-quantum-system">
@@ -33,6 +34,22 @@
   </div>
 
   <div class="form-row">
+    <label for="node-input-chosen_system">Simulator/Qubit System</label>
+    <select name="chosen_system" id="node-input-chosen_system">
+      <option value="Simulator">Simulator</option>
+      <option value="Qubit_System">Qubit System</option>
+    </select>
+  </div>
+
+  <div class="form-row">
+    <label for="node-input-preferred_output">Output Format</label>
+    <select name="preferred_output" id="node-input-preferred_output">
+      <option value="Results">Results Only</option>
+      <option value="Verbose">Verbose</option>
+    </select>
+  </div>
+
+  <div class="form-row">
     <label for="node-input-preferred_backend" id="user-backend"
       >Quantum Backend
     </label>
@@ -44,11 +61,4 @@
     />
   </div>
 
-  <div class="form-row">
-    <label for="node-input-preferred_output">Output Format</label>
-    <select name="preferred_output" id="node-input-preferred_output">
-      <option value="Verbose">Verbose</option>
-      <option value="Results">Results Only</option>
-    </select>
-  </div>
 </script>

--- a/quantum/nodes/ibm-quantum-system/ibm-quantum-system.html
+++ b/quantum/nodes/ibm-quantum-system/ibm-quantum-system.html
@@ -5,9 +5,9 @@
     defaults: {
       name: { value: "" },
       api_token: { value: "", required: true },
-      chosen_system: {value: ""},
+      chosen_system: { value: "" },
       preferred_backend: { value: "" },
-      shots: { value: 0, validate: RED.validators.number() },
+      shots: { value: 1, validate: RED.validators.number() },
       preferred_output: { value: "" },
     },
     inputs: 1,
@@ -56,7 +56,7 @@
 
   <div class="form-row">
     <label for="node-input-shots"><i class="fa fa-tag"></i> Shots</label>
-    <input type="number" id="node-input-shots" placeholder="1000"/>
+    <input type="number" min="1" id="node-input-shots" placeholder="1000"/>
   </div>
 
   <div class="form-row">

--- a/quantum/nodes/ibm-quantum-system/ibm-quantum-system.js
+++ b/quantum/nodes/ibm-quantum-system/ibm-quantum-system.js
@@ -100,13 +100,6 @@ module.exports = function(RED) {
           return;
         }
 
-        // Returns an error message if the given circuit is too big for the default simulator to run
-        if (node.qubits.length > 32 && node.chosenSystem == 'Simulator' && !node.preferredBackend) {
-          done(new Error(errors.DEFAULT_SIMULATOR_TOO_SMALL));
-          reset();
-          return;
-        }
-
         node.status({
           fill: 'orange',
           shape: 'dot',

--- a/quantum/nodes/ibm-quantum-system/ibm-quantum-system.js
+++ b/quantum/nodes/ibm-quantum-system/ibm-quantum-system.js
@@ -122,7 +122,11 @@ module.exports = function(RED) {
             script += util.format(snippets.IBMQ_SYSTEM_DEFAULT_QUBIT, node.apiToken, node.qubits.length);
           }
         } else {
-          script += util.format(snippets.IBMQ_SYSTEM_DEFAULT_SIMUL, node.apiToken, node.qubits.length);
+          if (node.qubits.length > 32) {
+            script += util.format(snippets.IBMQ_SYSTEM_DEFAULT_SIMUL, node.apiToken, node.qubits.length);
+          } else {
+            script += util.format(snippets.IBMQ_SYSTEM_QASM, node.apiToken);
+          }
         }
 
         if (node.outputPreference == 'Verbose') {

--- a/quantum/nodes/ibm-quantum-system/ibm-quantum-system.js
+++ b/quantum/nodes/ibm-quantum-system/ibm-quantum-system.js
@@ -118,7 +118,7 @@ module.exports = function(RED) {
         if (node.preferredBackend) {
           script += util.format(snippets.IBMQ_SYSTEM_PREFERRED, node.apiToken, node.preferredBackend);
         } else {
-          if (node.chosen_system == 'Qubit_System') {
+          if (node.chosenSystem == 'Qubit_System') {
             script += util.format(snippets.IBMQ_SYSTEM_DEFAULT, node.apiToken, node.qubits.length, 'False');
           } else {
             if (node.qubits.length > 32) {

--- a/quantum/nodes/ibm-quantum-system/ibm-quantum-system.js
+++ b/quantum/nodes/ibm-quantum-system/ibm-quantum-system.js
@@ -101,7 +101,7 @@ module.exports = function(RED) {
 
         // Returns an error message if the given circuit is too big for the default simulator to run
         if (node.qubits.length > 32 && node.chosenSystem == 'Simulator' && !node.preferredBackend) {
-          done(new Error(errors.QUBITS_FROM_DIFFERENT_CIRCUITS));
+          done(new Error(errors.DEFAULT_SIMULATOR_TOO_SMALL));
           reset();
           return;
         }

--- a/quantum/nodes/ibm-quantum-system/ibm-quantum-system.js
+++ b/quantum/nodes/ibm-quantum-system/ibm-quantum-system.js
@@ -115,12 +115,11 @@ module.exports = function(RED) {
 
         let script = '';
 
-        if (node.chosen_system == 'Qubit_System') {
-          if (node.preferredBackend) {
-            script += util.format(snippets.IBMQ_SYSTEM_PREFERRED, node.apiToken, node.preferredBackend);
-          } else {
-            script += util.format(snippets.IBMQ_SYSTEM_DEFAULT_QUBIT, node.apiToken, node.qubits.length);
-          }
+
+        if (node.preferredBackend) {
+          script += util.format(snippets.IBMQ_SYSTEM_PREFERRED, node.apiToken, node.preferredBackend);
+        } else if (node.chosen_system == 'Qubit_System') {
+          script += util.format(snippets.IBMQ_SYSTEM_DEFAULT_QUBIT, node.apiToken, node.qubits.length);
         } else {
           if (node.qubits.length > 32) {
             script += util.format(snippets.IBMQ_SYSTEM_DEFAULT_SIMUL, node.apiToken, node.qubits.length);

--- a/quantum/nodes/ibm-quantum-system/ibm-quantum-system.js
+++ b/quantum/nodes/ibm-quantum-system/ibm-quantum-system.js
@@ -12,7 +12,7 @@ module.exports = function(RED) {
     this.chosenSystem = config.chosen_system;
     this.preferredBackend = config.preferred_backend;
     this.outputPreference = config.preferred_output;
-    this.shots = config.shots;
+    this.shots = config.shots || 1;
     this.qubits = [];
     this.qreg = '';
     const node = this;
@@ -115,16 +115,17 @@ module.exports = function(RED) {
 
         let script = '';
 
-        console.log(node.chosenSystem);
         if (node.preferredBackend) {
           script += util.format(snippets.IBMQ_SYSTEM_PREFERRED, node.apiToken, node.preferredBackend);
-        } else if (node.chosen_system == 'Qubit_System') {
-          script += util.format(snippets.IBMQ_SYSTEM_DEFAULT, node.apiToken, node.qubits.length, 'False');
         } else {
-          if (node.qubits.length > 32) {
-            script += util.format(snippets.IBMQ_SYSTEM_DEFAULT, node.apiToken, node.qubits.length, 'True');
+          if (node.chosen_system == 'Qubit_System') {
+            script += util.format(snippets.IBMQ_SYSTEM_DEFAULT, node.apiToken, node.qubits.length, 'False');
           } else {
-            script += util.format(snippets.IBMQ_SYSTEM_QASM, node.apiToken);
+            if (node.qubits.length > 32) {
+              script += util.format(snippets.IBMQ_SYSTEM_DEFAULT, node.apiToken, node.qubits.length, 'True');
+            } else {
+              script += util.format(snippets.IBMQ_SYSTEM_QASM, node.apiToken);
+            }
           }
         }
 

--- a/quantum/nodes/ibm-quantum-system/ibm-quantum-system.js
+++ b/quantum/nodes/ibm-quantum-system/ibm-quantum-system.js
@@ -12,6 +12,7 @@ module.exports = function(RED) {
     this.chosenSystem = config.chosen_system;
     this.preferredBackend = config.preferred_backend;
     this.outputPreference = config.preferred_output;
+    this.shots = config.shots;
     this.qubits = [];
     this.qreg = '';
     const node = this;
@@ -121,13 +122,13 @@ module.exports = function(RED) {
             script += util.format(snippets.IBMQ_SYSTEM_DEFAULT_QUBIT, node.apiToken, node.qubits.length);
           }
         } else {
-          script += util.format(snippets.IBMQ_SYSTEM_DEFAULT_SIMUL, node.apiToken);
+          script += util.format(snippets.IBMQ_SYSTEM_DEFAULT_SIMUL, node.apiToken, node.qubits.length);
         }
 
         if (node.outputPreference == 'Verbose') {
-          script += snippets.IBMQ_SYSTEM_VERBOSE;
+          script += util.format(snippets.IBMQ_SYSTEM_VERBOSE, node.shots);
         } else {
-          script += snippets.IBMQ_SYSTEM_RESULT;
+          script += util.format(snippets.IBMQ_SYSTEM_RESULT, node.shots);
         }
 
         await shell.execute(script, (err, data) => {

--- a/quantum/nodes/ibm-quantum-system/ibm-quantum-system.js
+++ b/quantum/nodes/ibm-quantum-system/ibm-quantum-system.js
@@ -115,14 +115,14 @@ module.exports = function(RED) {
 
         let script = '';
 
-
+        console.log(node.chosenSystem);
         if (node.preferredBackend) {
           script += util.format(snippets.IBMQ_SYSTEM_PREFERRED, node.apiToken, node.preferredBackend);
         } else if (node.chosen_system == 'Qubit_System') {
-          script += util.format(snippets.IBMQ_SYSTEM_DEFAULT_QUBIT, node.apiToken, node.qubits.length);
+          script += util.format(snippets.IBMQ_SYSTEM_DEFAULT, node.apiToken, node.qubits.length, 'False');
         } else {
           if (node.qubits.length > 32) {
-            script += util.format(snippets.IBMQ_SYSTEM_DEFAULT_SIMUL, node.apiToken, node.qubits.length);
+            script += util.format(snippets.IBMQ_SYSTEM_DEFAULT, node.apiToken, node.qubits.length, 'True');
           } else {
             script += util.format(snippets.IBMQ_SYSTEM_QASM, node.apiToken);
           }

--- a/quantum/nodes/local-simulator/local-simulator.html
+++ b/quantum/nodes/local-simulator/local-simulator.html
@@ -24,7 +24,7 @@
     <input type="text" id="node-input-name" placeholder="Name" />
   </div>
   <div class="form-row">
-    <label for="node-input-shots"><i class="fa fa-tag"></i> Shots</label>
+    <label for="node-input-shots">Shots</label>
     <input type="number" id="node-input-shots" placeholder="1000"/>
   </div>
 </script>

--- a/quantum/snippets.js
+++ b/quantum/snippets.js
@@ -62,17 +62,10 @@ provider = IBMQ.enable_account('%s')
 backend_service = provider.get_backend('ibmq_qasm_simulator')
 `;
 
-const IBMQ_SYSTEM_DEFAULT_SIMUL =
+const IBMQ_SYSTEM_DEFAULT =
 `from qiskit.providers.ibmq import least_busy
 provider = IBMQ.enable_account('%s')
-backends = provider.backends(filters=lambda x: (x.configuration().n_qubits >= %s and x.configuration().simulator == True))
-backend_service = least_busy(backends)
-`;
-
-const IBMQ_SYSTEM_DEFAULT_QUBIT =
-`from qiskit.providers.ibmq import least_busy
-provider = IBMQ.enable_account('%s')
-backends = provider.backends(filters=lambda x: (x.configuration().n_qubits >= %s and x.configuration().simulator == False))
+backends = provider.backends(filters=lambda x: (x.configuration().n_qubits >= %s and x.configuration().simulator == %s))
 backend_service = least_busy(backends)
 `;
 
@@ -165,8 +158,7 @@ module.exports = {
   LOCAL_SIMULATOR,
   MULTI_CONTROLLED_U_GATE,
   IBMQ_SYSTEM_QASM,
-  IBMQ_SYSTEM_DEFAULT_SIMUL,
-  IBMQ_SYSTEM_DEFAULT_QUBIT,
+  IBMQ_SYSTEM_DEFAULT,
   IBMQ_SYSTEM_PREFERRED,
   IBMQ_SYSTEM_VERBOSE,
   IBMQ_SYSTEM_RESULT,

--- a/quantum/snippets.js
+++ b/quantum/snippets.js
@@ -56,7 +56,13 @@ counts = result.get_counts()
 print(counts)
 `;
 
-const IBMQ_SYSTEM_DEFAULT =
+const IBMQ_SYSTEM_DEFAULT_SIMUL =
+`from qiskit.providers.ibmq import least_busy
+provider = IBMQ.enable_account('%s')
+backend_service = provider.get_backend('ibmq_qasm_simulator')
+`;
+
+const IBMQ_SYSTEM_DEFAULT_QUBIT =
 `from qiskit.providers.ibmq import least_busy
 provider = IBMQ.enable_account('%s')
 backends = provider.backends(filters=lambda x: x.configuration().n_qubits >= %s)
@@ -151,7 +157,8 @@ module.exports = {
   MEASURE,
   LOCAL_SIMULATOR,
   MULTI_CONTROLLED_U_GATE,
-  IBMQ_SYSTEM_DEFAULT,
+  IBMQ_SYSTEM_DEFAULT_SIMUL,
+  IBMQ_SYSTEM_DEFAULT_QUBIT,
   IBMQ_SYSTEM_PREFERRED,
   IBMQ_SYSTEM_VERBOSE,
   IBMQ_SYSTEM_RESULT,

--- a/quantum/snippets.js
+++ b/quantum/snippets.js
@@ -59,13 +59,20 @@ print(counts)
 const IBMQ_SYSTEM_DEFAULT_SIMUL =
 `from qiskit.providers.ibmq import least_busy
 provider = IBMQ.enable_account('%s')
-backend_service = provider.get_backend('ibmq_qasm_simulator')
+backends = provider.backends(filters=lambda x: (x.configuration().n_qubits >= %s and x.configuration().simulator == true))
+backend_service = least_busy(backends)
 `;
+
+// if(%s <= 32):
+//   backend_service = provider.get_backend('ibmq_qasm_simulator')
+// else:
+//   backends = provider.backends(filters=lambda x: (x.configuration().n_qubits >= %s and x.configuration().simulator == true))
+//   backend_service = least_busy(backends)
 
 const IBMQ_SYSTEM_DEFAULT_QUBIT =
 `from qiskit.providers.ibmq import least_busy
 provider = IBMQ.enable_account('%s')
-backends = provider.backends(filters=lambda x: x.configuration().n_qubits >= %s)
+backends = provider.backends(filters=lambda x: (x.configuration().n_qubits >= %s and x.configuration().simulator == false))
 backend_service = least_busy(backends)
 `;
 
@@ -75,12 +82,12 @@ backend_service = provider.get_backend('%s')
 `;
 
 const IBMQ_SYSTEM_VERBOSE =
-`job = execute(qc, backend=backend_service)
+`job = execute(qc, backend=backend_service, shots=int(%s))
 job.result()
 `;
 
 const IBMQ_SYSTEM_RESULT =
-`job = execute(qc, backend=backend_service)
+`job = execute(qc, backend=backend_service, shots=int(%s))
 counts = job.result().get_counts()
 print(counts)
 `;

--- a/quantum/snippets.js
+++ b/quantum/snippets.js
@@ -56,23 +56,23 @@ counts = result.get_counts()
 print(counts)
 `;
 
+const IBMQ_SYSTEM_QASM =
+`from qiskit.providers.ibmq import least_busy
+provider = IBMQ.enable_account('%s')
+backend_service = provider.get_backend('ibmq_qasm_simulator')
+`;
+
 const IBMQ_SYSTEM_DEFAULT_SIMUL =
 `from qiskit.providers.ibmq import least_busy
 provider = IBMQ.enable_account('%s')
-backends = provider.backends(filters=lambda x: (x.configuration().n_qubits >= %s and x.configuration().simulator == true))
+backends = provider.backends(filters=lambda x: (x.configuration().n_qubits >= %s and x.configuration().simulator == True))
 backend_service = least_busy(backends)
 `;
-
-// if(%s <= 32):
-//   backend_service = provider.get_backend('ibmq_qasm_simulator')
-// else:
-//   backends = provider.backends(filters=lambda x: (x.configuration().n_qubits >= %s and x.configuration().simulator == true))
-//   backend_service = least_busy(backends)
 
 const IBMQ_SYSTEM_DEFAULT_QUBIT =
 `from qiskit.providers.ibmq import least_busy
 provider = IBMQ.enable_account('%s')
-backends = provider.backends(filters=lambda x: (x.configuration().n_qubits >= %s and x.configuration().simulator == false))
+backends = provider.backends(filters=lambda x: (x.configuration().n_qubits >= %s and x.configuration().simulator == False))
 backend_service = least_busy(backends)
 `;
 
@@ -82,12 +82,12 @@ backend_service = provider.get_backend('%s')
 `;
 
 const IBMQ_SYSTEM_VERBOSE =
-`job = execute(qc, backend=backend_service, shots=int(%s))
+`job = execute(qc, backend=backend_service, shots=%s)
 job.result()
 `;
 
 const IBMQ_SYSTEM_RESULT =
-`job = execute(qc, backend=backend_service, shots=int(%s))
+`job = execute(qc, backend=backend_service, shots=%s)
 counts = job.result().get_counts()
 print(counts)
 `;
@@ -164,6 +164,7 @@ module.exports = {
   MEASURE,
   LOCAL_SIMULATOR,
   MULTI_CONTROLLED_U_GATE,
+  IBMQ_SYSTEM_QASM,
   IBMQ_SYSTEM_DEFAULT_SIMUL,
   IBMQ_SYSTEM_DEFAULT_QUBIT,
   IBMQ_SYSTEM_PREFERRED,


### PR DESCRIPTION
### Purpose
This PR updates the IBM Quantum System node so that the QASM simulator is set as the default backend when no specific parameters are chosen by the user. If the user chooses to use a qubit system but does not specify a preferred backend, the least busy qubit system backend of the appropriate size is still chosen.


