### PR TITLE
Louis/command-tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,10 +5,12 @@ on:
     branches: [ master ]
     paths:
       - 'quantum/**'
+      - 'test/**'
   pull_request:
     branches: [ master ]
     paths:
       - 'quantum/**'
+      - 'test/**'
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "setup": "(npm run link && npm run venv) && echo Setup complete - run 'npm start' to open Node-RED",
     "link": "bash bin/link.sh || bin/link.sh",
     "venv": "bash bin/pyvenv.sh || bin/pyvenv.sh",
-    "test": "mocha \"test/**/*_spec.js\"",
+    "test": "mocha \"test/**/*_spec.js\" --timeout 10000",
     "clean": "rm -r venv/ & npm uninstall --prefix ~/.node-red/ node-red-contrib-quantum",
     "lint": "eslint --fix --ignore-path .gitignore .",
     "postinstall": "npm run venv"

--- a/test/flow-builder.js
+++ b/test/flow-builder.js
@@ -12,6 +12,7 @@ const NODES = {
   'identity-gate': require('../quantum/nodes/identity-gate/identity-gate.js'),
   'local-simulator': require('../quantum/nodes/local-simulator/local-simulator.js'),
   'measure': require('../quantum/nodes/measure/measure.js'),
+  'multi-controlled-u-gate': require('../quantum/nodes/multi-controlled-u-gate/multi-controlled-u-gate.js'),
   'not-gate': require('../quantum/nodes/not-gate/not-gate.js'),
   'phase-gate': require('../quantum/nodes/phase-gate/phase-gate.js'),
   'quantum-circuit': require('../quantum/nodes/quantum-circuit/quantum-circuit.js'),

--- a/test/flow-builder.js
+++ b/test/flow-builder.js
@@ -43,6 +43,24 @@ class FlowBuilder {
   }
 
   /**
+   * Return the ID of the first node.
+   *
+   * @return {string} The nodes ID string.
+  */
+  get inputId() {
+    return this.flow[0].id;
+  }
+
+  /**
+   * Return the ID of the last node.
+   *
+   * @return {string} The nodes ID string.
+  */
+  get outputId() {
+    return this.flow[this.flow.length - 1].id;
+  }
+
+  /**
    * Add a quantum node to the flow.
    *
    * @param {string} name The name of the node.

--- a/test/flow-builder.js
+++ b/test/flow-builder.js
@@ -72,7 +72,7 @@ class FlowBuilder {
     if (!NODES.hasOwnProperty(name)) {
       throw new Error(`Failed to find node ${name}`);
     }
-    let json = {id: id, wires: [wires], type: name, name: name.replace(/-/g, ' ')};
+    let json = {id: id, wires: wires, type: name, name: name.replace(/-/g, ' ')};
     Object.assign(json, properties);
     if (!this.nodes.includes(NODES[name])) {
       this.nodes.push(NODES[name]);

--- a/test/flow-builder.js
+++ b/test/flow-builder.js
@@ -74,7 +74,9 @@ class FlowBuilder {
     }
     let json = {id: id, wires: [wires], type: name, name: name.replace(/-/g, ' ')};
     Object.assign(json, properties);
-    this.nodes.push(NODES[name]);
+    if (!this.nodes.includes(NODES[name])) {
+      this.nodes.push(NODES[name]);
+    }
     this.flow.push(json);
   }
 

--- a/test/nodes/barrier_spec.js
+++ b/test/nodes/barrier_spec.js
@@ -1,6 +1,9 @@
-const barrierNode = require('../../quantum/nodes/barrier/barrier.js');
+const util = require('util');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const barrierNode = require('../../quantum/nodes/barrier/barrier.js');
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('BarrierNode', function() {
@@ -15,5 +18,15 @@ describe('BarrierNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(barrierNode, 'barrier', done);
+  });
+
+  it('execute command', function(done) {
+    let command = util.format(snippets.BARRIER, '0, ');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('barrier', 'n1', [['n2']], {outputs: '1'});
+    flow.addOutput('n2');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/bloch-sphere_spec.js
+++ b/test/nodes/bloch-sphere_spec.js
@@ -1,6 +1,8 @@
-const blochSphereNode = require('../../quantum/nodes/bloch-sphere/bloch-sphere.js');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const blochSphereNode = require('../../quantum/nodes/bloch-sphere/bloch-sphere.js');
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('BlochSphereNode', function() {
@@ -15,5 +17,20 @@ describe('BlochSphereNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(blochSphereNode, 'bloch-sphere', done);
+  });
+
+  it('execute command', function(done) {
+    let command = snippets.BLOCH_SPHERE + snippets.ENCODE_IMAGE;
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1'], ['n2'], ['n3']],
+        {structure: 'qubits', outputs: '3', qbitsreg: '3', cbitsreg: '1'});
+    flow.add('hadamard-gate', 'n1', [['n4']]);
+    flow.add('hadamard-gate', 'n2', [['n4']]);
+    flow.add('not-gate', 'n3', [['n4']]);
+    flow.add('toffoli-gate', 'n4', [['n5'], ['n5'], ['n5']], {targetPosition: 'Middle'});
+    flow.add('bloch-sphere', 'n5', [['n6']]);
+    flow.addOutput('n6');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/circuit-diagram_spec.js
+++ b/test/nodes/circuit-diagram_spec.js
@@ -1,6 +1,8 @@
-const circuitDiagramNode = require('../../quantum/nodes/circuit-diagram/circuit-diagram.js');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const circuitDiagramNode = require('../../quantum/nodes/circuit-diagram/circuit-diagram.js');
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('CircuitDiagramNode', function() {
@@ -15,5 +17,17 @@ describe('CircuitDiagramNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(circuitDiagramNode, 'circuit-diagram', done);
+  });
+
+  it('execute command', function(done) {
+    let command = snippets.CIRCUIT_DIAGRAM + snippets.ENCODE_IMAGE;
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('hadamard-gate', 'n1', [['n2']]);
+    flow.add('measure', 'n2', [['n3']], {selectedBit: '0'});
+    flow.add('circuit-diagram', 'n3', [['n4']]);
+    flow.addOutput('n4');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/classical-register_spec.js
+++ b/test/nodes/classical-register_spec.js
@@ -1,7 +1,9 @@
-const classicalRegisterNode = require('../../quantum/nodes/classical-register/classical-register.js');
+const util = require('util');
 const testUtil = require('../test-util');
+const classicalRegisterNode = require('../../quantum/nodes/classical-register/classical-register.js');
+const {FlowBuilder} = require('../flow-builder');
 const nodeTestHelper = testUtil.nodeTestHelper;
-
+const snippets = require('../../quantum/snippets.js');
 
 describe('ClassicalRegisterNode', function() {
   beforeEach(function(done) {
@@ -15,5 +17,17 @@ describe('ClassicalRegisterNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(classicalRegisterNode, 'classical-register', done);
+  });
+
+  it('execute command', function(done) {
+    let command = util.format(snippets.CLASSICAL_REGISTER, '_test', '3, "test"');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1'], ['n2']],
+        {structure: 'registers', outputs: '2', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('quantum-register', 'n1', [['n3']], {outputs: '1'});
+    flow.add('classical-register', 'n2', [], {classicalBits: '3', name: 'test'});
+    flow.addOutput('n3');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/cnot-gate_spec.js
+++ b/test/nodes/cnot-gate_spec.js
@@ -1,6 +1,9 @@
-const cnotGateNode = require('../../quantum/nodes/cnot-gate/cnot-gate.js');
+const util = require('util');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const cnotGateNode = require('../../quantum/nodes/cnot-gate/cnot-gate.js');
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('CnotGateNode', function() {
@@ -15,5 +18,16 @@ describe('CnotGateNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(cnotGateNode, 'cnot-gate', done);
+  });
+
+  it('execute command', function(done) {
+    let command = util.format(snippets.CNOT_GATE, '1', '0');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1'], ['n1']],
+        {structure: 'qubits', outputs: '2', qbitsreg: '2', cbitsreg: '1'});
+    flow.add('cnot-gate', 'n1', [['n2']], {targetPosition: 'Upper'});
+    flow.addOutput('n2');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/controlled-u-gate_spec.js
+++ b/test/nodes/controlled-u-gate_spec.js
@@ -1,6 +1,9 @@
-const controlledUGateNode = require('../../quantum/nodes/controlled-u-gate/controlled-u-gate.js');
+const util = require('util');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const controlledUGateNode = require('../../quantum/nodes/controlled-u-gate/controlled-u-gate.js');
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('ControlledUGateNode', function() {
@@ -15,5 +18,17 @@ describe('ControlledUGateNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(controlledUGateNode, 'controlled-u-gate', done);
+  });
+
+  it('execute command', function(done) {
+    let command = util.format(snippets.CU_GATE, '0*pi', '0*pi', '0*pi', '0*pi', '1', '0');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1'], ['n1']],
+        {structure: 'qubits', outputs: '2', qbitsreg: '2', cbitsreg: '1'});
+    flow.add('controlled-u-gate', 'n1', [['n2']],
+        {targetPosition: 'Upper', theta: '0', phi: '0', lambda: '0', gamma: '0'});
+    flow.addOutput('n2');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/hadamard-gate_spec.js
+++ b/test/nodes/hadamard-gate_spec.js
@@ -1,6 +1,9 @@
-const hadamardGateNode = require('../../quantum/nodes/hadamard-gate/hadamard-gate.js');
+const util = require('util');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const hadamardGateNode = require('../../quantum/nodes/hadamard-gate/hadamard-gate.js');
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('HadamardGateNode', function() {
@@ -15,5 +18,15 @@ describe('HadamardGateNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(hadamardGateNode, 'hadamard-gate', done);
+  });
+
+  it('execute command', function(done) {
+    let command = util.format(snippets.HADAMARD_GATE, '0');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('hadamard-gate', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/ibm-quantum-system_spec.js
+++ b/test/nodes/ibm-quantum-system_spec.js
@@ -1,7 +1,12 @@
-const ibmQuantumSystemNode = require('../../quantum/nodes/ibm-quantum-system/ibm-quantum-system.js');
+const util = require('util');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const ibmQuantumSystemNode = require('../../quantum/nodes/ibm-quantum-system/ibm-quantum-system.js');
+const snippets = require('../../quantum/snippets.js');
 
+// DO NOT COMMIT YOUR API TOKEN!
+const API_TOKEN = '';
 
 describe('IBMQuantumSystemNode', function() {
   beforeEach(function(done) {
@@ -16,4 +21,18 @@ describe('IBMQuantumSystemNode', function() {
   it('load node', function(done) {
     testUtil.isLoaded(ibmQuantumSystemNode, 'ibm-quantum-system', done);
   });
+
+  xit('execute command', function(done) {
+    // Disabled for now until we can use GitHub secrets to pass an API key to this test for CI.
+    let command = util.format(snippets.IBMQ_SYSTEM_DEFAULT + snippets.IBMQ_SYSTEM_RESULT, API_TOKEN, '1');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('hadamard-gate', 'n1', [['n2']]);
+    flow.add('measure', 'n2', [['n3']], {selectedBit: '0'});
+    flow.add('ibm-quantum-system', 'n3', [['n4']], {api_token: API_TOKEN,
+      preferred_backend: '', preferred_output: ' Results'});
+    flow.addOutput('n4');
+
+    testUtil.commandExecuted(flow, command, done);
+  }).timeout(180000); // Needs long timeout as it takes awhile for IBM server to respond
 });

--- a/test/nodes/identity-gate_spec.js
+++ b/test/nodes/identity-gate_spec.js
@@ -1,6 +1,9 @@
-const identityGateNode = require('../../quantum/nodes/identity-gate/identity-gate.js');
+const util = require('util');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const identityGateNode = require('../../quantum/nodes/identity-gate/identity-gate.js');
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('IdentityGateNode', function() {
@@ -15,5 +18,15 @@ describe('IdentityGateNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(identityGateNode, 'identity-gate', done);
+  });
+
+  it('execute command', function(done) {
+    let command = util.format(snippets.IDENTITY, '0');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('identity-gate', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/local-simulator_spec.js
+++ b/test/nodes/local-simulator_spec.js
@@ -1,10 +1,8 @@
 const util = require('util');
-const assert = require('chai').assert;
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
 const {FlowBuilder} = require('../flow-builder');
 const localSimulatorNode = require('../../quantum/nodes/local-simulator/local-simulator.js');
-const shell = require('../../quantum/python.js').PythonShell;
 const snippets = require('../../quantum/snippets.js');
 
 
@@ -14,7 +12,6 @@ describe('LocalSimulatorNode', function() {
   });
 
   afterEach(function(done) {
-    shell.stop();
     nodeTestHelper.unload();
     nodeTestHelper.stopServer(done);
   });
@@ -23,29 +20,15 @@ describe('LocalSimulatorNode', function() {
     testUtil.isLoaded(localSimulatorNode, 'local-simulator', done);
   });
 
-  it('execute script', function(done) {
-    const flow = new FlowBuilder();
+  it('execute command', function(done) {
+    let command = util.format(snippets.LOCAL_SIMULATOR, '1');
+    let flow = new FlowBuilder();
     flow.add('quantum-circuit', 'n0', ['n1'], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
     flow.add('hadamard-gate', 'n1', ['n2']);
     flow.add('measure', 'n2', ['n3'], {selectedBit: '0'});
     flow.add('local-simulator', 'n3', ['n4'], {shots: '1'});
     flow.addOutput('n4');
 
-    nodeTestHelper.load(flow.nodes, flow.flow, function() {
-      let n0 = nodeTestHelper.getNode('n0');
-      let n4 = nodeTestHelper.getNode('n4');
-
-      n4.on('input', function(msg) {
-        try {
-          let command = util.format(snippets.LOCAL_SIMULATOR, '1');
-          assert.strictEqual(shell.lastCommand, command);
-          done();
-        } catch (err) {
-          done(err);
-        }
-      });
-
-      n0.receive({payload: ''});
-    });
+    testUtil.commandExecuted(flow, 'n0', 'n4', command, done);
   });
 });

--- a/test/nodes/local-simulator_spec.js
+++ b/test/nodes/local-simulator_spec.js
@@ -23,10 +23,10 @@ describe('LocalSimulatorNode', function() {
   it('execute command', function(done) {
     let command = util.format(snippets.LOCAL_SIMULATOR, '1');
     let flow = new FlowBuilder();
-    flow.add('quantum-circuit', 'n0', ['n1'], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
-    flow.add('hadamard-gate', 'n1', ['n2']);
-    flow.add('measure', 'n2', ['n3'], {selectedBit: '0'});
-    flow.add('local-simulator', 'n3', ['n4'], {shots: '1'});
+    flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('hadamard-gate', 'n1', [['n2']]);
+    flow.add('measure', 'n2', [['n3']], {selectedBit: '0'});
+    flow.add('local-simulator', 'n3', [['n4']], {shots: '1'});
     flow.addOutput('n4');
 
     testUtil.commandExecuted(flow, command, done);

--- a/test/nodes/local-simulator_spec.js
+++ b/test/nodes/local-simulator_spec.js
@@ -29,6 +29,6 @@ describe('LocalSimulatorNode', function() {
     flow.add('local-simulator', 'n3', ['n4'], {shots: '1'});
     flow.addOutput('n4');
 
-    testUtil.commandExecuted(flow, 'n0', 'n4', command, done);
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/measure_spec.js
+++ b/test/nodes/measure_spec.js
@@ -1,6 +1,9 @@
-const measureNode = require('../../quantum/nodes/measure/measure.js');
+const util = require('util');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const measureNode = require('../../quantum/nodes/measure/measure.js');
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('MeasureNode', function() {
@@ -15,5 +18,16 @@ describe('MeasureNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(measureNode, 'measure', done);
+  });
+
+  it('execute command', function(done) {
+    let command = util.format(snippets.MEASURE, '0, 0');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', ['n1'], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('hadamard-gate', 'n1', ['n2']);
+    flow.add('measure', 'n2', ['n3'], {selectedBit: '0'});
+    flow.addOutput('n3');
+
+    testUtil.commandExecuted(flow, 'n0', 'n3', command, done);
   });
 });

--- a/test/nodes/measure_spec.js
+++ b/test/nodes/measure_spec.js
@@ -23,9 +23,9 @@ describe('MeasureNode', function() {
   it('execute command', function(done) {
     let command = util.format(snippets.MEASURE, '0, 0');
     let flow = new FlowBuilder();
-    flow.add('quantum-circuit', 'n0', ['n1'], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
-    flow.add('hadamard-gate', 'n1', ['n2']);
-    flow.add('measure', 'n2', ['n3'], {selectedBit: '0'});
+    flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('hadamard-gate', 'n1', [['n2']]);
+    flow.add('measure', 'n2', [['n3']], {selectedBit: '0'});
     flow.addOutput('n3');
 
     testUtil.commandExecuted(flow, command, done);

--- a/test/nodes/measure_spec.js
+++ b/test/nodes/measure_spec.js
@@ -28,6 +28,6 @@ describe('MeasureNode', function() {
     flow.add('measure', 'n2', ['n3'], {selectedBit: '0'});
     flow.addOutput('n3');
 
-    testUtil.commandExecuted(flow, 'n0', 'n3', command, done);
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/multi-controlled-u-gate_spec.js
+++ b/test/nodes/multi-controlled-u-gate_spec.js
@@ -1,6 +1,9 @@
-const multiControlledUGateNode = require('../../quantum/nodes/multi-controlled-u-gate/multi-controlled-u-gate.js');
+const util = require('util');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const multiControlledUGateNode = require('../../quantum/nodes/multi-controlled-u-gate/multi-controlled-u-gate.js');
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('MultiControlledUGateNode', function() {
@@ -15,5 +18,17 @@ describe('MultiControlledUGateNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(multiControlledUGateNode, 'multi-controlled-u-gate', done);
+  });
+
+  it('execute command', function(done) {
+    let command = util.format(snippets.MULTI_CONTROLLED_U_GATE, '0*pi', '0*pi', '0*pi', '1', '[ 1, 0 ]');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1'], ['n1']],
+        {structure: 'qubits', outputs: '2', qbitsreg: '2', cbitsreg: '1'});
+    flow.add('multi-controlled-u-gate', 'n1', [['n2'], ['n2']],
+        {outputs: '2', nbControls: '1', targetPosition: '0', theta: '0', phi: '0', lambda: '0'});
+    flow.addOutput('n2');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/multi-controlled-u-gate_spec.js
+++ b/test/nodes/multi-controlled-u-gate_spec.js
@@ -1,0 +1,19 @@
+const multiControlledUGateNode = require('../../quantum/nodes/multi-controlled-u-gate/multi-controlled-u-gate.js');
+const testUtil = require('../test-util');
+const nodeTestHelper = testUtil.nodeTestHelper;
+
+
+describe('MultiControlledUGateNode', function() {
+  beforeEach(function(done) {
+    nodeTestHelper.startServer(done);
+  });
+
+  afterEach(function(done) {
+    nodeTestHelper.unload();
+    nodeTestHelper.stopServer(done);
+  });
+
+  it('load node', function(done) {
+    testUtil.isLoaded(multiControlledUGateNode, 'multi-controlled-u-gate', done);
+  });
+});

--- a/test/nodes/not-gate_spec.js
+++ b/test/nodes/not-gate_spec.js
@@ -1,6 +1,9 @@
-const notGateNode = require('../../quantum/nodes/not-gate/not-gate.js');
+const util = require('util');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const notGateNode = require('../../quantum/nodes/not-gate/not-gate.js');
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('NotGateNode', function() {
@@ -15,5 +18,15 @@ describe('NotGateNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(notGateNode, 'not-gate', done);
+  });
+
+  it('execute command', function(done) {
+    let command = util.format(snippets.NOT_GATE, '0');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('not-gate', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/phase-gate_spec.js
+++ b/test/nodes/phase-gate_spec.js
@@ -1,6 +1,9 @@
-const phaseGateNode = require('../../quantum/nodes/phase-gate/phase-gate.js');
+const util = require('util');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const phaseGateNode = require('../../quantum/nodes/phase-gate/phase-gate.js');
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('PhaseGateNode', function() {
@@ -15,5 +18,15 @@ describe('PhaseGateNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(phaseGateNode, 'phase-gate', done);
+  });
+
+  it('execute command', function(done) {
+    let command = util.format(snippets.PHASE_GATE, '0*pi', '0');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('phase-gate', 'n1', [['n2']], {phase: '0'});
+    flow.addOutput('n2');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/quantum-circuit_spec.js
+++ b/test/nodes/quantum-circuit_spec.js
@@ -1,6 +1,9 @@
-const quantumCircuitNode = require('../../quantum/nodes/quantum-circuit/quantum-circuit.js');
+const util = require('util');
 const testUtil = require('../test-util');
+const quantumCircuitNode = require('../../quantum/nodes/quantum-circuit/quantum-circuit.js');
+const {FlowBuilder} = require('../flow-builder');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('QuantumCircuitNode', function() {
@@ -15,5 +18,14 @@ describe('QuantumCircuitNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(quantumCircuitNode, 'quantum-circuit', done);
+  });
+
+  it('execute command', function(done) {
+    let command = util.format(snippets.IMPORTS + snippets.QUANTUM_CIRCUIT, '1, 1');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.addOutput('n1');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/quantum-register_spec.js
+++ b/test/nodes/quantum-register_spec.js
@@ -1,6 +1,9 @@
-const quantumRegisterNode = require('../../quantum/nodes/quantum-register/quantum-register.js');
+const util = require('util');
 const testUtil = require('../test-util');
+const quantumRegisterNode = require('../../quantum/nodes/quantum-register/quantum-register.js');
+const {FlowBuilder} = require('../flow-builder');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('QuantumRegisterNode', function() {
@@ -15,5 +18,16 @@ describe('QuantumRegisterNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(quantumRegisterNode, 'quantum-register', done);
+  });
+
+  xit('execute command', function(done) {
+    // Test is disabled until issue #87 is fixed
+    let command = util.format(snippets.QUANTUM_REGISTER, '0', '1, "quantum_register"');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'registers', outputs: '1', qbitsreg: '1', cbitsreg: '0'});
+    flow.add('quantum-register', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/reset_spec.js
+++ b/test/nodes/reset_spec.js
@@ -1,6 +1,9 @@
-const resetNode = require('../../quantum/nodes/reset/reset.js');
+const util = require('util');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const resetNode = require('../../quantum/nodes/reset/reset.js');
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('ResetNode', function() {
@@ -15,5 +18,15 @@ describe('ResetNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(resetNode, 'reset', done);
+  });
+
+  it('execute command', function(done) {
+    let command = util.format(snippets.RESET, '0');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('reset', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/rotation-gate_spec.js
+++ b/test/nodes/rotation-gate_spec.js
@@ -1,6 +1,9 @@
-const rotationGateNode = require('../../quantum/nodes/rotation-gate/rotation-gate.js');
+const util = require('util');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const rotationGateNode = require('../../quantum/nodes/rotation-gate/rotation-gate.js');
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('RotationGateNode', function() {
@@ -15,5 +18,15 @@ describe('RotationGateNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(rotationGateNode, 'rotation-gate', done);
+  });
+
+  it('execute command', function(done) {
+    let command = util.format(snippets.ROTATION_GATE, 'x', '-0.2*pi', 0);
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('rotation-gate', 'n1', [['n2']], {axis: 'x', angle: '-0.2'});
+    flow.addOutput('n2');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/swap_spec.js
+++ b/test/nodes/swap_spec.js
@@ -1,6 +1,9 @@
-const swapNode = require('../../quantum/nodes/swap/swap.js');
+const util = require('util');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const swapNode = require('../../quantum/nodes/swap/swap.js');
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('SwapNode', function() {
@@ -15,5 +18,16 @@ describe('SwapNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(swapNode, 'swap', done);
+  });
+
+  it('execute command', function(done) {
+    let command = util.format(snippets.SWAP, '0', '1');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1'], ['n1']],
+        {structure: 'qubits', outputs: '2', qbitsreg: '2', cbitsreg: '1'});
+    flow.add('swap', 'n1', [['n2']]);
+    flow.addOutput('n2');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/nodes/toffoli-gate_spec.js
+++ b/test/nodes/toffoli-gate_spec.js
@@ -1,6 +1,9 @@
-const toffoliGateNode = require('../../quantum/nodes/toffoli-gate/toffoli-gate.js');
+const util = require('util');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const toffoliGateNode = require('../../quantum/nodes/toffoli-gate/toffoli-gate.js');
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('ToffoliGateNode', function() {

--- a/test/nodes/toffoli-gate_spec.js
+++ b/test/nodes/toffoli-gate_spec.js
@@ -19,4 +19,18 @@ describe('ToffoliGateNode', function() {
   it('load node', function(done) {
     testUtil.isLoaded(toffoliGateNode, 'toffoli-gate', done);
   });
+
+  it('execute command', function(done) {
+    let command = util.format(snippets.TOFFOLI_GATE, '0', '2', '1');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1'], ['n2'], ['n3']],
+        {structure: 'qubits', outputs: '3', qbitsreg: '3', cbitsreg: '1'});
+    flow.add('hadamard-gate', 'n1', [['n4']]);
+    flow.add('hadamard-gate', 'n2', [['n4']]);
+    flow.add('not-gate', 'n3', [['n4']]);
+    flow.add('toffoli-gate', 'n4', [['n5'], ['n5'], ['n5']], {targetPosition: 'Middle'});
+    flow.addOutput('n5');
+
+    testUtil.commandExecuted(flow, command, done);
+  });
 });

--- a/test/nodes/unitary-gate_spec.js
+++ b/test/nodes/unitary-gate_spec.js
@@ -1,6 +1,9 @@
-const unitaryGateNode = require('../../quantum/nodes/unitary-gate/unitary-gate.js');
+const util = require('util');
 const testUtil = require('../test-util');
 const nodeTestHelper = testUtil.nodeTestHelper;
+const {FlowBuilder} = require('../flow-builder');
+const unitaryGateNode = require('../../quantum/nodes/unitary-gate/unitary-gate.js');
+const snippets = require('../../quantum/snippets.js');
 
 
 describe('UnitaryGateNode', function() {
@@ -15,5 +18,15 @@ describe('UnitaryGateNode', function() {
 
   it('load node', function(done) {
     testUtil.isLoaded(unitaryGateNode, 'unitary-gate', done);
+  });
+
+  it('execute command', function(done) {
+    let command = util.format(snippets.UNITARY_GATE, '0*pi', '0*pi', '0*pi', '0');
+    let flow = new FlowBuilder();
+    flow.add('quantum-circuit', 'n0', [['n1']], {structure: 'qubits', outputs: '1', qbitsreg: '1', cbitsreg: '1'});
+    flow.add('unitary-gate', 'n1', [['n2']], {theta: '0', phi: '0', lambda: '0'});
+    flow.addOutput('n2');
+
+    testUtil.commandExecuted(flow, command, done);
   });
 });

--- a/test/python_spec.js
+++ b/test/python_spec.js
@@ -9,6 +9,10 @@ NameError: name 'x' is not defined`;
 
 
 describe('PythonShell', function() {
+  before(() => {
+    shell.stop();
+  });
+
   describe('#constructor', function() {
     it('python path is default', async function() {
       assert.match(shell.path, /venv\/bin\/python|venv\/Scripts\/python.exe/);

--- a/test/python_spec.js
+++ b/test/python_spec.js
@@ -9,10 +9,6 @@ NameError: name 'x' is not defined`;
 
 
 describe('PythonShell', function() {
-  before(() => {
-    shell.stop();
-  });
-
   describe('#constructor', function() {
     it('python path is default', async function() {
       assert.match(shell.path, /venv\/bin\/python|venv\/Scripts\/python.exe/);

--- a/test/python_spec.js
+++ b/test/python_spec.js
@@ -10,6 +10,10 @@ NameError: name 'x' is not defined`;
 
 describe('PythonShell', function() {
   describe('#constructor', function() {
+    before(() => {
+      shell.stop();
+    });
+
     it('python path is default', async function() {
       assert.match(shell.path, /venv\/bin\/python|venv\/Scripts\/python.exe/);
     });

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -19,10 +19,10 @@ function isLoaded(node, nodeName, done) {
   });
 }
 
-function commandExecuted(flowBuilder, inputId, outputId, command, done) {
+function commandExecuted(flowBuilder, command, done) {
   nodeTestHelper.load(flowBuilder.nodes, flowBuilder.flow, function() {
-    let inputNode = nodeTestHelper.getNode(inputId);
-    let outputNode = nodeTestHelper.getNode(outputId);
+    let inputNode = nodeTestHelper.getNode(flowBuilder.inputId);
+    let outputNode = nodeTestHelper.getNode(flowBuilder.outputId);
 
     outputNode.on('input', function() {
       try {

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -30,11 +30,11 @@ function commandExecuted(flowBuilder, command, done) {
       try {
         assert.strictEqual(shell.lastCommand, command);
         done();
-        called = true;
       } catch (err) {
         done(err);
       } finally {
         shell.stop();
+        called = true;
       }
     });
 

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -1,5 +1,6 @@
 const assert = require('chai').assert;
 const nodeTestHelper = require('node-red-node-test-helper');
+const shell = require('../quantum/python.js').PythonShell;
 
 nodeTestHelper.init(require.resolve('node-red'));
 
@@ -18,7 +19,28 @@ function isLoaded(node, nodeName, done) {
   });
 }
 
+function commandExecuted(flowBuilder, inputId, outputId, command, done) {
+  nodeTestHelper.load(flowBuilder.nodes, flowBuilder.flow, function() {
+    let inputNode = nodeTestHelper.getNode(inputId);
+    let outputNode = nodeTestHelper.getNode(outputId);
+
+    outputNode.on('input', function() {
+      try {
+        assert.strictEqual(shell.lastCommand, command);
+        done();
+      } catch (err) {
+        done(err);
+      } finally {
+        shell.stop();
+      }
+    });
+
+    inputNode.receive({payload: ''});
+  });
+}
+
 module.exports = {
   nodeTestHelper,
   isLoaded,
+  commandExecuted,
 };

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -23,11 +23,14 @@ function commandExecuted(flowBuilder, command, done) {
   nodeTestHelper.load(flowBuilder.nodes, flowBuilder.flow, function() {
     let inputNode = nodeTestHelper.getNode(flowBuilder.inputId);
     let outputNode = nodeTestHelper.getNode(flowBuilder.outputId);
+    let called = false;
 
     outputNode.on('input', function() {
+      if (called) return;
       try {
         assert.strictEqual(shell.lastCommand, command);
         done();
+        called = true;
       } catch (err) {
         done(err);
       } finally {


### PR DESCRIPTION
### Purpose
Adds unit tests for ensuring that the Python command was executed successfully. Also fixed some bugs.

### Changes
- Add "execute command" tests (f0d17b1c351776907858b32af73b47a5ea49634c, 6ff8eee49309a48dd2cf733bac12c2cb4b5bf006, 2d3aa708bfa30d70a6350047bce13649dec028a5, 98fc4b7c37668aff637956a2a766aa05cd990c04, 93d84a457cc281a3d1c443dd6a82091da65e7431, 4e72d2d6d8d042c2b8dd3f9641fbcb72c6d80ec7).
- Add util function for checking if the expected command was executed (cfefb2e5cc6f7c1763439932a7708652c5727f81).
- Add `inputId()` and `outputId()` methods for `FlowBuilder`, used to get the IDs of the first and last nodes (3942ef0873a2dab2b3cb8e7c3d8e741e1c7c1645).
- Ensure tests are run when only `test/` is modified (b6a0039725897d779b7635c1b02347dd340a5312).
- Increased timeout limit for all tests (eeb80f38c4cfb196dac948e6f02f7d1457aa027d).
- Fix bug where an error would be raised if adding multiple nodes of the same type to a `FlowBuilder` flow (40ff92785c5d58c0f375a290b703dce72fc3eb6d).
- Fix bug which limited how wires could be configured in `FlowBuilder` (d1ed9f359b309f184613f5b76b8c897777f22af6).
- Fix bug where `PythonShell` tests would fail due to the instance not being stopped before running the test suite (51579b62bde90b77c21d9fc585ffc373f2c3e05c).
